### PR TITLE
add POC view endpoint

### DIFF
--- a/app/microservice/register.json
+++ b/app/microservice/register.json
@@ -17,6 +17,13 @@
             "path": "/api/v1/geostore/:id"
         }]
     }, {
+        "url": "/v1/geostore/:id/view",
+        "method": "GET",
+        "endpoints": [{
+            "method": "GET",
+            "path": "/api/v1/geostore/:id/view"
+        }]
+    }, {
         "url": "/v1/geostore/admin/:iso",
         "method": "GET",
         "endpoints": [{

--- a/app/src/errors/errorCreatingGist.js
+++ b/app/src/errors/errorCreatingGist.js
@@ -1,0 +1,11 @@
+'use strict';
+
+class ErrorCreatingGist extends Error{
+
+    constructor(message){
+        super(message);
+        this.name = 'ErrorCreatingGist';
+        this.message = message;
+    }
+}
+module.exports = ErrorCreatingGist;

--- a/app/src/services/geojsonioService.js
+++ b/app/src/services/geojsonioService.js
@@ -1,0 +1,53 @@
+'use strict';
+var logger = require('logger');
+var ErrorCreatingGist = require('errors/errorCreatingGist');
+var GitHubApi = require('github');
+var github = new GitHubApi({
+        version: '3.0.0',
+        protocol: 'https'
+    });
+var MAX_URL_LEN = 150e3;
+
+class GeoJsonIOService {
+
+  static * view(geojson) {
+
+    // if this is a multiplygon, grab the first feature in the collection
+    // and ditch the rest-- only need type and coordinates properties
+    if (geojson.features[0].geometry.type === 'MultiPolygon') {
+      logger.debug('found multipolygon');
+      geojson = {'type': 'MultiPolygon',
+                 'coordinates': geojson.features[0].geometry.coordinates};
+    } else {
+
+    for (var i = 0; i < geojson.features.length; i++) {
+        // doesn't register when set to {} for some reason
+        geojson.features[i].properties = null;
+    }}
+
+      if (JSON.stringify(geojson).length <= MAX_URL_LEN) {
+          return 'http://geojson.io/' + ('#data=data:application/json,' + encodeURIComponent(
+              JSON.stringify(geojson)));
+
+      } else {
+          logger.debug('saving to github gist');
+          let res = yield github.gists.create({
+              description: '',
+              public: true,
+              files: {
+                  'map.geojson': {
+                      content: JSON.stringify(geojson)
+                  }
+              }
+          });
+          if (res.data.html_url) {
+            return res.data.html_url;
+          }
+          throw new ErrorCreatingGist(`Error creating gist`);
+      }
+  }
+}
+
+
+
+module.exports = GeoJsonIOService;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "country-data": "0.0.24",
     "ct-register-microservice-node": "2.1.2",
     "geojsonhint": "1.2.0",
+    "github": "9.2.0",
     "jsonapi-serializer": "2.1.1",
     "koa": "1.1.2",
     "koa-bodyparser": "2.0.1",


### PR DESCRIPTION
I don't know about anyone else, but I spend a lot of time copying geojson from the /geostore/<hash> endpoint, then pasting it into geojson.io.

This code will simplify that process-- if you can add /view to any geostore hash, and it will return either a link to a geojson.io url (if the geojson is small enough) or will create a github gist, and give you that URL.

Most of the code is taken directly from [geojsonio-cli](https://github.com/mapbox/geojsonio-cli), which I love dearly.

Feel free to edit/fix my bad javascript. Also happy to discuss if you don't think this is a good idea to include in the API.