### PR TITLE
Adds geostore/area endpoint

### DIFF
--- a/app/microservice/register.json
+++ b/app/microservice/register.json
@@ -12,6 +12,13 @@
             "path": "/api/v1/geostore"
         }]
     }, {
+        "url": "/v1/geostore/area",
+        "method": "POST",
+        "endpoints": [{
+            "method": "POST",
+            "path": "/api/v1/geostore/area"
+        }]
+    },{
         "url": "/v1/geostore/:id",
         "method": "GET",
         "endpoints": [{

--- a/app/src/serializers/areaSerializer.js
+++ b/app/src/serializers/areaSerializer.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var logger = require('logger');
+
+class AreaSerializer {
+  
+  static serialize(data) {
+    return {
+        data: {
+            'type': "geomArea",
+            'attributes': {
+                'bbox': data.bbox,
+                'areaHa': data.areaHa
+                }
+            }
+        };
+    }
+}
+
+module.exports = AreaSerializer;

--- a/app/src/services/geoStoreService.js
+++ b/app/src/services/geoStoreService.js
@@ -155,6 +155,39 @@ class GeoStoreService {
         });
     }
 
+    static * calculateBBox(geoStore){
+        logger.debug('Calculating bbox');
+        geoStore.bbox = turf.bbox(geoStore.geojson);
+        yield geoStore.save();
+        return geoStore;
+    }
+
+    static * calculateArea(geojson, data) {
+
+        let geoStore = {
+            geojson: geojson
+        };
+
+        if (data && data.provider) {
+          let geoJsonObtained = yield GeoStoreService.obtainGeoJSON(data.provider);
+          geoStore.geojson = geoJsonObtained.geojson;
+          geoStore.areaHa = geoJsonObtained.area_ha;
+        }
+
+        logger.debug('Converting geojson');
+        logger.debug('Converting', JSON.stringify(geoStore.geojson));
+        geoStore.geojson = GeoJSONConverter.convert(geoStore.geojson);
+        logger.debug('Result', JSON.stringify(geoStore.geojson));
+        if (geoStore.areaHa === undefined) {
+            geoStore.areaHa = turf.area(geoStore.geojson) / 10000; // convert to ha2
+        }
+        if(!geoStore.bbox) {
+            geoStore.bbox = turf.bbox(geoStore.geojson);
+        }
+        return yield geoStore
+
+    }
+
 }
 
 module.exports = GeoStoreService;

--- a/app/src/services/geoStoreService.js
+++ b/app/src/services/geoStoreService.js
@@ -178,12 +178,9 @@ class GeoStoreService {
         logger.debug('Converting', JSON.stringify(geoStore.geojson));
         geoStore.geojson = GeoJSONConverter.convert(geoStore.geojson);
         logger.debug('Result', JSON.stringify(geoStore.geojson));
-        if (geoStore.areaHa === undefined) {
-            geoStore.areaHa = turf.area(geoStore.geojson) / 10000; // convert to ha2
-        }
-        if(!geoStore.bbox) {
-            geoStore.bbox = turf.bbox(geoStore.geojson);
-        }
+        geoStore.areaHa = turf.area(geoStore.geojson) / 10000; // convert to ha2
+        geoStore.bbox = turf.bbox(geoStore.geojson);
+
         return yield geoStore
 
     }


### PR DESCRIPTION
This PR adds a POST endpoint to `api/v1/geostore` that returns the area (Ha) and a bounding box for any geojson in the body of the request (without creating a new geostore!)

e.g.

`url = https://production-api.globalforestwatch.org/api/v1/geostore/area` 

```json

body = {
"geojson": {
        "type": "Polygon",
        "coordinates": [
        	[[36.6724, 5.9181], 
        	[36.6861, 4.9979], 
        	[36.7932, 5.0773], 
        	[36.6724, 5.9181]]]
    }
}

```

Returns:

```json

{
    "data": {
        "type": "geomArea",
        "attributes": {
            "bbox": [
                36.6724,
                4.9979,
                36.7932,
                5.9181
            ],
            "areaHa": 61457.72347512001
        }
    }
}

```
 