### PR TITLE
repair geometry

### DIFF
--- a/app/src/converters/geoJSONConverter.js
+++ b/app/src/converters/geoJSONConverter.js
@@ -2,25 +2,52 @@
 
 let logger = require('logger');
 
-module.exports.convert = function(data){
+module.exports.makeFeatureCollection = function(data){
     if(data.type === 'FeatureCollection'){
         logger.debug('Is a FeatureCollection');
+        data.features.properties = null;
         return data;
     } else if(data.type === 'Feature'){
         logger.debug('Is a feature');
+        data.properties = null;
         return {
             type: 'FeatureCollection',
-            features:[data]
+            features:[data],
+           /*crs: { 
+                    type: 'name', 
+                    properties: { 
+                        name: 'urn:ogc:def:crs:OGC:1.3:CRS84' 
+                    } 
+            }*/
         };
     } else{
-        logger.debug('is a geometry');
+        logger.debug('Is a geometry');
         return {
             type: 'FeatureCollection',
             features:[{
                 type: 'Feature',
-                properties: {},
+                properties: null,
                 geometry: data
-            }]
+            }],
+          /*  crs: { 
+                    type: 'name', 
+                    properties: { 
+                        name: 'urn:ogc:def:crs:OGC:1.3:CRS84' 
+                    } 
+            }*/
         };
+    }
+};
+
+module.exports.getGeometry = function(data){
+    if(data.type === 'FeatureCollection'){
+        logger.debug('Is a FeatureCollection');
+        return data.features[0].geometry;
+    } else if(data.type === 'Feature'){
+        logger.debug('Is a feature');
+        return data.geometry;
+    } else{
+        logger.debug('Is a geometry');
+        return data;
     }
 };

--- a/app/test/unit/converters/geoJSONConverter.test.js
+++ b/app/test/unit/converters/geoJSONConverter.test.js
@@ -6,7 +6,7 @@ var GeoJSONConverter = require('converters/geoJSONConverter');
 
 
 describe('Error serializer test', function () {
-    var result = {
+    var featureCollectionExample = {
         type: 'FeatureCollection',
         features: [{
             type: 'Feature',
@@ -52,69 +52,100 @@ describe('Error serializer test', function () {
     });
 
     it('Create correct geojson from geometry', function () {
-        let converted = GeoJSONConverter.convert(geometryExample);
+        let converted = GeoJSONConverter.makeFeatureCollection(geometryExample);
         converted.should.have.property('type');
-        converted.type.should.be.equal(result.type);
+        converted.type.should.be.equal(featureCollectionExample.type);
         converted.should.have.property('features');
         converted.features.should.be.a.Array();
-        converted.features.should.length(result.features.length);
-        let feature = converted.features[0];
-
+        converted.features.should.length(featureCollectionExample.features.length);
+       
+	let feature = converted.features[0];
         feature.should.have.property('type');
-        feature.type.should.be.equal(result.features[0].type);
+        feature.type.should.be.equal(featureCollectionExample.features[0].type);
         feature.should.have.property('geometry');
         feature.geometry.should.be.a.Object();
-        let geometry = feature.geometry;
+        
+	let geometry = feature.geometry;
         geometry.should.have.property('type');
-        geometry.type.should.be.equal(result.features[0].geometry.type);
+        geometry.type.should.be.equal(featureCollectionExample.features[0].geometry.type);
         geometry.should.have.a.property('coordinates');
         geometry.coordinates.should.be.a.Array();
-        geometry.coordinates.should.length(result.features[0].geometry.coordinates.length);
-
-
+        geometry.coordinates.should.length(featureCollectionExample.features[0].geometry.coordinates.length);
     });
+
     it('Create correct geojson from feature', function () {
-        let converted = GeoJSONConverter.convert(featureExample);
+        let converted = GeoJSONConverter.makeFeatureCollection(featureExample);
         converted.should.have.property('type');
-        converted.type.should.be.equal(result.type);
+        converted.type.should.be.equal(featureCollectionExample.type);
         converted.should.have.property('features');
         converted.features.should.be.a.Array();
-        converted.features.should.length(result.features.length);
-        let feature = converted.features[0];
-
+        converted.features.should.length(featureCollectionExample.features.length);
+        
+	let feature = converted.features[0];
         feature.should.have.property('type');
-        feature.type.should.be.equal(result.features[0].type);
+        feature.type.should.be.equal(featureCollectionExample.features[0].type);
         feature.should.have.property('geometry');
         feature.geometry.should.be.a.Object();
-        let geometry = feature.geometry;
+        
+	let geometry = feature.geometry;
         geometry.should.have.property('type');
-        geometry.type.should.be.equal(result.features[0].geometry.type);
+        geometry.type.should.be.equal(featureCollectionExample.features[0].geometry.type);
         geometry.should.have.a.property('coordinates');
         geometry.coordinates.should.be.a.Array();
-        geometry.coordinates.should.length(result.features[0].geometry.coordinates.length);
+        geometry.coordinates.should.length(featureCollectionExample.features[0].geometry.coordinates.length);
     });
-    it('Create correct geojson.', function () {
-        let converted = GeoJSONConverter.convert(result);
+
+    it('Create correct geojson from feature collection', function () {
+        let converted = GeoJSONConverter.makeFeatureCollection(featureCollectionExample);
         converted.should.have.property('type');
-        converted.type.should.be.equal(result.type);
+        converted.type.should.be.equal(featureCollectionExample.type);
         converted.should.have.property('features');
         converted.features.should.be.a.Array();
-        converted.features.should.length(result.features.length);
-        let feature = converted.features[0];
+        converted.features.should.length(featureCollectionExample.features.length);
 
+        let feature = converted.features[0];
         feature.should.have.property('type');
-        feature.type.should.be.equal(result.features[0].type);
+        feature.type.should.be.equal(featureCollectionExample.features[0].type);
         feature.should.have.property('geometry');
         feature.geometry.should.be.a.Object();
+
         let geometry = feature.geometry;
         geometry.should.have.property('type');
-        geometry.type.should.be.equal(result.features[0].geometry.type);
+        geometry.type.should.be.equal(featureCollectionExample.features[0].geometry.type);
         geometry.should.have.a.property('coordinates');
         geometry.coordinates.should.be.a.Array();
-        geometry.coordinates.should.length(result.features[0].geometry.coordinates.length);
+        geometry.coordinates.should.length(featureCollectionExample.features[0].geometry.coordinates.length);
+    });
+
+    it('Get geometry from from feature collection', function () {
+        let geometry = GeoJSONConverter.getGeometry(featureCollectionExample);
+	geometry.should.have.property('type');
+        geometry.type.should.be.equal(geometryExample.type);
+        geometry.should.have.a.property('coordinates');
+        geometry.coordinates.should.be.a.Array();
+        geometry.coordinates.should.length(geometryExample.coordinates.length);
+    });
+
+    it('Get geometry from from feature collection', function () {
+        let geometry = GeoJSONConverter.getGeometry(featureExample);
+	geometry.should.have.property('type');
+        geometry.type.should.be.equal(geometryExample.type);
+        geometry.should.have.a.property('coordinates');
+        geometry.coordinates.should.be.a.Array();
+        geometry.coordinates.should.length(geometryExample.coordinates.length);
+    });
+
+    it('Get geometry from from feature collection', function () {
+        let geometry = GeoJSONConverter.getGeometry(geometryExample);
+	geometry.should.have.property('type');
+        geometry.type.should.be.equal(geometryExample.type);
+        geometry.should.have.a.property('coordinates');
+        geometry.coordinates.should.be.a.Array();
+        geometry.coordinates.should.length(geometryExample.coordinates.length);
     });
 
     after(function* () {
 
     });
 });
+


### PR DESCRIPTION
Add method to geostore service to repair geometries before saving them.
We had incidents where users submitted corrupted geometries which couldn't be saved. The new method makes use of the ST_makevalid function in CARTO to repair geometries prior to saving.