### PR TITLE
Add precision and slug filter to coverage

### DIFF
--- a/app/src/routes/api/v1/coverageRouter.js
+++ b/app/src/routes/api/v1/coverageRouter.js
@@ -76,7 +76,11 @@ class CoverageRouter {
     if (!geoStore || !geoStore.geojson) {
       this.throw(404, 'Use not found');
     }
-    let result = yield CoverageService.getWorld(geoStore.geojson.features[0].geometry);
+    const options = {
+      precision: this.query.precision,
+      slugs: this.query.slugs && this.query.slugs.split(',')
+    }
+    let result = yield CoverageService.getWorld(geoStore.geojson.features[0].geometry, options);
     this.body = CoverageSerializer.serialize({
       layers: result
     });

--- a/app/src/services/coverageService.js
+++ b/app/src/services/coverageService.js
@@ -35,6 +35,7 @@ const USE = `SELECT slug FROM coverage_layers cl, {{useTable}} c where c.cartodb
 const COVERAGES = `SELECT ST_AsGeoJSON(the_geom) as geojson, coverage_slug as slug, slug as layerSlug from coverage_layers`;
 
 const WORLD = `SELECT slug FROM coverage_layers where ST_INTERSECTS(the_geom, ST_SetSRID(ST_GeomFromGeoJSON('{{{geojson}}}'), 4326))`;
+const REDUCED_WORLD = `with p as (SELECT slug, st_simplify(the_geom , {{{precision}}}) as the_geom FROM coverage_layers {{{filter}}}) SELECT slug FROM p  where ST_INTERSECTS(the_geom, ST_SetSRID(ST_GeomFromGeoJSON('{{{geojson}}}'), 4326))`;
 
 
 var executeThunk = function(client, sql, params) {
@@ -126,14 +127,16 @@ class CoverageService {
   }
 
   *
-  getWorld(geojson) {
+  getWorld(geojson, { precision, slugs }) {
     logger.info('Getting layers that intersect');
 
     let params = {
-      geojson: JSON.stringify(geojson)
+      precision,
+      geojson: JSON.stringify(geojson),
+      filter: slugs && `WHERE slug IN (${slugs.join(',')})`
     };
-
-    let data = yield executeThunk(this.client, WORLD, params);
+    const query = (precision || slugs) ? REDUCED_WORLD : WORLD;
+    let data = yield executeThunk(this.client, query, params);
     if (data.rows && data.rows.length > 0) {
       return data.rows.map(item => item.slug);
     }


### PR DESCRIPTION
Having a lot of issues with the coverage from FW... so this PR includes a simplify query params and filter by slug (because we only need to check GLAD for now)

New params: 
```
precision: number for the geom
slugs: comma separated string ('umd_as_it_happens, forma')
```