### PR TITLE
Geostore v2 (GADM 3.6)

### DIFF
--- a/app/microservice/register.json
+++ b/app/microservice/register.json
@@ -109,5 +109,103 @@
             "method": "GET",
             "path": "/api/v1/coverage/intersect"
         }]
+    }, {
+        "url": "/v2/geostore/area",
+        "method": "POST",
+        "endpoints": [{
+            "method": "POST",
+            "path": "/api/v2/geostore/area"
+        }]
+    },{
+        "url": "/v2/geostore/:id",
+        "method": "GET",
+        "endpoints": [{
+            "method": "GET",
+            "path": "/api/v2/geostore/:id"
+        }]
+    }, {
+        "url": "/v2/geostore/:id/view",
+        "method": "GET",
+        "endpoints": [{
+            "method": "GET",
+            "path": "/api/v2/geostore/:id/view"
+        }]
+    }, {
+        "url": "/v2/geostore/admin/:iso",
+        "method": "GET",
+        "endpoints": [{
+            "method": "GET",
+            "path": "/api/v2/geostore/admin/:iso"
+        }]
+    }, {
+        "url": "/v2/geostore/admin/list",
+        "method": "GET",
+        "endpoints": [{
+            "method": "GET",
+            "path": "/api/v2/geostore/admin/list"
+        }]
+    }, {
+        "url": "/v2/geostore/admin/:iso/:id1",
+        "method": "GET",
+        "endpoints": [{
+            "method": "GET",
+            "path": "/api/v2/geostore/admin/:iso/:id1"
+        }]
+    }, {
+        "url": "/v2/geostore/admin/:iso/:id1/:id2",
+        "method": "GET",
+        "endpoints": [{
+            "method": "GET",
+            "path": "/api/v2/geostore/admin/:iso/:id1/:id2"
+        }]
+    },{
+        "url": "/v2/geostore/use/:name/:id",
+        "method": "GET",
+        "endpoints": [{
+            "method": "GET",
+            "path": "/api/v2/geostore/use/:name/:id"
+        }]
+    }, {
+        "url": "/v2/geostore/wdpa/:id",
+        "method": "GET",
+        "endpoints": [{
+            "method": "GET",
+            "path": "/api/v2/geostore/wdpa/:id"
+        }]
+    }, {
+        "url": "/v2/coverage/intersect/use/:name/:id",
+        "method": "GET",
+        "endpoints": [{
+            "method": "GET",
+            "path": "/api/v2/coverage/intersect/use/:name/:id"
+        }]
+    }, {
+        "url": "/v2/coverage/intersect/admin/:iso",
+        "method": "GET",
+        "endpoints": [{
+            "method": "GET",
+            "path": "/api/v2/coverage/intersect/admin/:iso"
+        }]
+    }, {
+        "url": "/v2/coverage/intersect/admin/:iso/:id1",
+        "method": "GET",
+        "endpoints": [{
+            "method": "GET",
+            "path": "/api/v2/coverage/intersect/admin/:iso/:id1"
+        }]
+    }, {
+        "url": "/v2/coverage/intersect/wdpa/:id",
+        "method": "GET",
+        "endpoints": [{
+            "method": "GET",
+            "path": "/api/v2/coverage/intersect/wdpa/:id"
+        }]
+    }, {
+        "url": "/v2/coverage/intersect",
+        "method": "GET",
+        "endpoints": [{
+            "method": "GET",
+            "path": "/api/v2/coverage/intersect"
+        }]
     }]
 }

--- a/app/src/models/geoStore.js
+++ b/app/src/models/geoStore.js
@@ -36,6 +36,7 @@ var GeoStore = new Schema({
         name: {type: String, required: false},
         id1: {type: Number, required: false},
         id2: {type: Number, required: false},
+        gadm: {type: String, required: false},
         wdpaid: {type: Number, required: false},
         use: {
             use:{type: String, required: false},

--- a/app/src/routes/api/v2/coverageRouter.js
+++ b/app/src/routes/api/v2/coverageRouter.js
@@ -1,0 +1,96 @@
+'use strict';
+
+var Router = require('koa-router');
+var logger = require('logger');
+var CoverageSerializer = require('serializers/coverageSerializer');
+var CoverageValidator = require('validators/coverageValidator');
+var GeoStore = require('models/geoStore');
+var IdConnection = require('models/idConnection');
+var CoverageServiceV2 = require('services/coverageServiceV2');
+var GeoStoreServiceV2 = require('services/geoStoreServiceV2');
+var CoverageDuplicated = require('errors/coverageDuplicated');
+var CoverageNotFound = require('errors/coverageNotFound');
+var GeoJSONNotFound = require('errors/geoJSONNotFound');
+
+var router = new Router({
+  prefix: '/coverage'
+});
+
+
+class CoverageRouterV2 {
+
+  static * intersectUse() {
+    logger.info(`Calculating intersect with use ${this.params.name} and id ${this.params.id}`);
+    let useTable = null;
+    switch (this.params.name) {
+      case 'mining':
+        useTable = 'gfw_mining';
+        break;
+      case 'oilpalm':
+        useTable = 'gfw_oil_palm';
+        break;
+      case 'fiber':
+        useTable = 'gfw_wood_fiber';
+        break;
+      case 'logging':
+        useTable = 'gfw_logging';
+        break;
+      default:
+        this.throw(400, 'Name param invalid');
+    }
+    let result = yield CoverageServiceV2.getUse(useTable, this.params.id);
+    this.body = CoverageSerializer.serialize({
+      layers: result
+    });
+  }
+
+  static * intersectIsoRegion() {
+    logger.info(`Calculating intersect with iso ${this.params.iso} and region ${this.params.id1}`);
+    let result = null;
+    if (!this.params.id1) {
+      result = yield CoverageServiceV2.getNational(this.params.iso);
+    } else {
+      result = yield CoverageServiceV2.getSubnational(this.params.iso, this.params.id1);
+    }
+    this.body = CoverageSerializer.serialize({
+      layers: result
+    });
+  }
+
+  static * intersectWdpa() {
+    logger.info(`Calculating intersect with wdpa ${this.params.id}`);
+    let result = yield CoverageServiceV2.getWdpa(this.params.id);
+
+    this.body = CoverageSerializer.serialize({
+      layers: result
+    });
+
+  }
+
+  static * intersectGeo() {
+    logger.info(`Calculating intersect with geostore ${this.query.geostore}`);
+    this.assert(this.query.geostore, 400, 'GeoJSON param required');
+    let geoStore = yield GeoStoreServiceV2.getGeostoreById(this.query.geostore);
+
+
+    if (!geoStore || !geoStore.geojson) {
+      this.throw(404, 'Use not found');
+    }
+    const options = {
+      slugs: this.query.slugs && this.query.slugs.split(',')
+    };
+    let result = yield CoverageServiceV2.getWorld(geoStore.geojson.features[0].geometry, options);
+    this.body = CoverageSerializer.serialize({
+      layers: result
+    });
+  }
+
+}
+
+router.get('/intersect', CoverageRouterV2.intersectGeo);
+router.get('/intersect/admin/:iso', CoverageRouterV2.intersectIsoRegion);
+router.get('/intersect/admin/:iso/:id1', CoverageRouterV2.intersectIsoRegion);
+router.get('/intersect/use/:name/:id', CoverageRouterV2.intersectUse);
+router.get('/intersect/wdpa/:id', CoverageRouterV2.intersectWdpa);
+
+module.exports = router;

--- a/app/src/routes/api/v2/geoStoreRouter.js
+++ b/app/src/routes/api/v2/geoStoreRouter.js
@@ -1,0 +1,219 @@
+'use strict';
+
+var Router = require('koa-router');
+var logger = require('logger');
+var GeoStoreValidator = require('validators/geoStoreValidator');
+var GeoJSONSerializer = require('serializers/geoJSONSerializer');
+var AreaSerializer = require('serializers/areaSerializer');
+var CountryListSerializer = require('serializers/countryListSerializer');
+var GeoStore = require('models/geoStore');
+var IdConnection = require('models/idConnection');
+var CartoServiceV2 = require('services/cartoDBServiceV2');
+var GeoStoreServiceV2 = require('services/geoStoreServiceV2');
+var GeoJsonIOService = require('services/geojsonioService');
+var ProviderNotFound = require('errors/providerNotFound');
+var GeoJSONNotFound = require('errors/geoJSONNotFound');
+var geojsonToArcGIS = require('arcgis-to-geojson-utils').geojsonToArcGIS;
+var arcgisToGeoJSON = require('arcgis-to-geojson-utils').arcgisToGeoJSON;
+
+var router = new Router({
+    prefix: '/geostore'
+});
+
+class GeoStoreRouterV2 {
+
+    static * getGeoStoreById() {
+        this.assert(this.params.hash, 400, 'Hash param not found');
+        logger.debug('Getting geostore by hash %s', this.params.hash);
+        var geoStore = null;
+
+        try {
+            geoStore = yield GeoStoreServiceV2.getGeostoreById(this.params.hash);
+            if(!geoStore) {
+                this.throw(404, 'GeoStore not found');
+                return;
+            }
+            logger.debug('GeoStore found. Returning...');
+            if(!geoStore.bbox) {
+                geoStore = yield GeoStoreServiceV2.calculateBBox(geoStore);
+            }
+            if (this.query.format && this.query.format === 'esri') {
+              logger.debug('esri', geojsonToArcGIS(geoStore.geojson)[0]);
+              geoStore.esrijson = geojsonToArcGIS(geoStore.geojson)[0].geometry;
+            }
+
+            this.body = GeoJSONSerializer.serialize(geoStore);
+
+        } catch(e) {
+            logger.error(e);
+            throw e;
+        }
+    }
+
+    static * createGeoStore() {
+        logger.info('Saving GeoStore');
+        try{
+          const data = {
+            provider: this.request.body.provider,
+            info: {},
+            lock: this.request.body.lock ? this.request.body.lock : false
+          };
+          if (!this.request.body.geojson && !this.request.body.esrijson && !this.request.body.provider){
+            this.throw(400, 'geojson, esrijson or provider required');
+            return;
+          }
+          if (this.request.body.esrijson){
+            this.request.body.geojson = arcgisToGeoJSON(this.request.body.esrijson);
+          }
+
+          let geostore = yield GeoStoreServiceV2.saveGeostore(this.request.body.geojson, data);
+          logger.debug(JSON.stringify(geostore.geojson));
+          this.body = GeoJSONSerializer.serialize(geostore);
+        } catch(err){
+            if (err instanceof ProviderNotFound || err instanceof GeoJSONNotFound){
+                this.throw(400, err.message);
+                return ;
+            }
+            throw err;
+        }
+    }
+
+    static * getArea() {
+        logger.info('Retreiving Polygon Area');
+        try{
+          const data = {
+            provider: this.request.body.provider,
+            info: {},
+            lock: this.request.body.lock ? this.request.body.lock : false
+          };
+          if (!this.request.body.geojson && !this.request.body.esrijson && !this.request.body.provider){
+            this.throw(400, 'geojson, esrijson or provider required');
+            return;
+          }
+          if (this.request.body.esrijson){
+            this.request.body.geojson = arcgisToGeoJSON(this.request.body.esrijson);
+          }
+          let geostore = yield GeoStoreServiceV2.calculateArea(this.request.body.geojson, data);
+          logger.debug(JSON.stringify(geostore.geojson));
+          this.body = AreaSerializer.serialize(geostore);
+        } catch(err){
+            if (err instanceof ProviderNotFound || err instanceof GeoJSONNotFound){
+                this.throw(400, err.message);
+                return ;
+            }
+            throw err;
+        }
+    }
+
+    static * getNational() {
+        logger.info('Obtaining national data geojson (GADM v3.6)');
+        const data = yield CartoServiceV2.getNational(this.params.iso);
+        if (!data) {
+          this.throw(404, 'Country not found');
+        }
+        this.body = GeoJSONSerializer.serialize(data);
+    }
+
+    static * getNationalList() {
+        logger.info('Obtaining national list (GADM v3.6)');
+        const data = yield CartoServiceV2.getNationalList();
+        if (!data) {
+          this.throw(404, 'Empty List');
+        }
+        this.body = CountryListSerializer.serialize(data);
+    }
+
+    static * getSubnational() {
+        logger.info('Obtaining subnational data geojson (GADM v3.6)');
+        const data = yield CartoServiceV2.getSubnational(this.params.iso, this.params.id1);
+        if (!data) {
+          this.throw(404, 'Country/Region not found');
+        }
+        this.body = GeoJSONSerializer.serialize(data);
+    }
+
+    static * getAdmin2() {
+        logger.info('Obtaining Admin2 data geojson (GADM v3.6)');
+        const data = yield CartoServiceV2.getAdmin2(this.params.iso, this.params.id1, this.params.id2);
+        if (!data) {
+          this.throw(404, 'Country/Admin1/Admin2 not found');
+        }
+        this.body = GeoJSONSerializer.serialize(data);
+    }
+
+    static * use() {
+        logger.info('Obtaining use data with name %s and id %s', this.params.name, this.params.id);
+        let useTable = null;
+        switch (this.params.name) {
+            case 'mining':
+                useTable = 'gfw_mining';
+                break;
+            case 'oilpalm':
+                useTable = 'gfw_oil_palm';
+                break;
+            case 'fiber':
+                useTable = 'gfw_wood_fiber';
+                break;
+            case 'logging':
+                useTable = 'gfw_logging';
+                break;
+            default:
+                this.throw(400, 'Name param invalid');
+        }
+        if (!useTable) {
+            this.throw(404, 'Name not found');
+        }
+        const data = yield CartoServiceV2.getUse(useTable, this.params.id);
+        if (!data) {
+          this.throw(404, 'Use not found');
+        }
+        this.body = GeoJSONSerializer.serialize(data);
+    }
+
+    static * wdpa() {
+        logger.info('Obtaining wpda data with id %s', this.params.id);
+
+        const data = yield CartoServiceV2.getWdpa(this.params.id);
+        if (!data) {
+          this.throw(404, 'Wdpa not found');
+        }
+        this.body = GeoJSONSerializer.serialize(data);
+    }
+
+    static * view() {
+        this.assert(this.params.hash, 400, 'Hash param not found');
+        logger.debug('Getting geostore by hash %s', this.params.hash);
+        var geoStore = null;
+        var geojsonIoPath = null;
+
+        try {
+            geoStore = yield GeoStoreServiceV2.getGeostoreById(this.params.hash);
+
+            if(!geoStore) {
+                this.throw(404, 'GeoStore not found');
+                return;
+            }
+            logger.debug('GeoStore found. Returning...');
+
+            geojsonIoPath = yield GeoJsonIOService.view(geoStore.geojson);
+            this.body = {'view_link': geojsonIoPath};
+
+        } catch(e) {
+            logger.error(e);
+            throw e;
+        }
+    }
+}
+
+router.get('/:hash', GeoStoreRouterV2.getGeoStoreById);
+router.post('/', GeoStoreValidator.create, GeoStoreRouterV2.createGeoStore);
+router.post('/area', GeoStoreValidator.create, GeoStoreRouterV2.getArea);
+router.get('/admin/:iso', GeoStoreRouterV2.getNational);
+router.get('/admin/list', GeoStoreRouterV2.getNationalList);
+router.get('/admin/:iso/:id1', GeoStoreRouterV2.getSubnational);
+router.get('/admin/:iso/:id1/:id2', GeoStoreRouterV2.getAdmin2);
+router.get('/use/:name/:id', GeoStoreRouterV2.use);
+router.get('/wdpa/:id', GeoStoreRouterV2.wdpa);
+router.get('/:hash/view', GeoStoreRouterV2.view);
+
+module.exports = router;

--- a/app/src/services/cartoDBServiceV2.js
+++ b/app/src/services/cartoDBServiceV2.js
@@ -5,26 +5,23 @@ var config = require('config');
 var CartoDB = require('cartodb');
 var Mustache = require('mustache');
 var JSONAPIDeserializer = require('jsonapi-serializer').Deserializer;
-const GeoStoreService = require('services/geoStoreService');
+const GeoStoreServiceV2 = require('services/geoStoreServiceV2');
 
 const ISO = `SELECT ST_AsGeoJSON(st_makevalid(the_geom)) AS geojson, (ST_Area(geography(the_geom))/10000) as area_ha, name_0 as name
-        FROM gadm2_countries_simple
-        WHERE iso = UPPER('{{iso}}')`;
+        FROM gadm36_adm0
+        WHERE gid_0 = UPPER('{{iso}}')`;
 
 const ISO_NAME = `SELECT iso, name_0 as name
-        FROM gadm2_countries_simple
-        WHERE iso in `;
+        FROM gadm36_adm0
+        WHERE gid_0 in `;
 
 const ID1 = `SELECT ST_AsGeoJSON(st_makevalid(the_geom)) AS geojson, (ST_Area(geography(the_geom))/10000) as area_ha
-        FROM gadm28_adm1
-        WHERE iso = UPPER('{{iso}}')
-          AND id_1 = {{id1}}`;
+        FROM gadm36_adm1
+        WHERE gid_1 = '{{id1}}'`;
 
 const ID2 = `SELECT ST_AsGeoJSON(st_makevalid(the_geom)) AS geojson, (ST_Area(geography(the_geom))/10000) as area_ha
-        FROM gadm28_adm2_geostore
-        WHERE iso = UPPER('{{iso}}')
-          AND id_1 = {{id1}}
-          AND id_2 = {{id2}}`;
+        FROM gadm36_adm2
+        WHERE gid_2 = '{{id2}}'`;
 
 const WDPA = `SELECT ST_AsGeoJSON(st_makevalid(p.the_geom)) AS geojson, (ST_Area(geography(the_geom))/10000) as area_ha
         FROM (
@@ -60,7 +57,7 @@ const deserializer = function(obj) {
 };
 
 
-class CartoDBService {
+class CartoDBServiceV2 {
 
     constructor() {
         this.client = new CartoDB.SQL({
@@ -75,7 +72,7 @@ class CartoDBService {
             'info.id1': null
         };
         logger.debug('Checking existing national geo');
-        let existingGeo = yield GeoStoreService.getGeostoreByInfoProps(query);
+        let existingGeo = yield GeoStoreServiceV2.getGeostoreByInfoProps(query);
         logger.debug('Existed geo', existingGeo);
         if (existingGeo) {
           logger.debug('Return national geojson stored');
@@ -90,11 +87,11 @@ class CartoDBService {
           const geoData = {
             info : {
                 'iso': iso.toUpperCase(),
-                gadm: '2.8'
+                gadm: '3.6'
             }
           };
           geoData.info.name = result.name;
-          existingGeo = yield GeoStoreService.saveGeostore(JSON.parse(result.geojson), geoData);
+          existingGeo = yield GeoStoreServiceV2.saveGeostore(JSON.parse(result.geojson), geoData);
           logger.debug('Return national geojson from carto');
           return existingGeo;
         }
@@ -103,7 +100,7 @@ class CartoDBService {
 
     * getNationalList(){
         logger.debug('Request national list names from carto');
-        const countryList = yield GeoStoreService.getNationalList();
+        const countryList = yield GeoStoreServiceV2.getNationalList();
         const iso_values_map = countryList.map(el => {
             return el.info.iso;
         });
@@ -132,12 +129,11 @@ class CartoDBService {
     * getSubnational(iso, id1) {
       logger.debug('Obtaining subnational of iso %s and id1', iso, id1);
       let params = {
-        iso: iso.toUpperCase(),
-        id1: parseInt(id1, 10)
+        id1: `${iso.toUpperCase()}.${parseInt(id1, 10)}_1`
       };
 
       logger.debug('Checking existing subnational geo');
-      let existingGeo = yield GeoStoreService.getGeostoreByInfo(params);
+      let existingGeo = yield GeoStoreServiceV2.getGeostoreByInfo(params);
       logger.debug('Existed geo', existingGeo);
       if (existingGeo) {
         logger.debug('Return subnational geojson stored');
@@ -151,10 +147,13 @@ class CartoDBService {
         let result = data.rows[0];
         logger.debug('Saving national geostore');
         const geoData = {
-          info: params,
-          gadm: '2.8'
+          info: {
+              iso: iso.toUpperCase(),
+              id1: parseInt(id1, 10),
+              gadm: '3.6'
+          }
         };
-        existingGeo = yield GeoStoreService.saveGeostore(JSON.parse(result.geojson), geoData);
+        existingGeo = yield GeoStoreServiceV2.saveGeostore(JSON.parse(result.geojson), geoData);
         return existingGeo;
       }
       return null;
@@ -163,14 +162,11 @@ class CartoDBService {
     * getAdmin2(iso, id1, id2) {
       logger.debug('Obtaining admin2 of iso %s, id1 and id2', iso, id1, id2);
       let params = {
-        iso: iso.toUpperCase(),
-        id1: parseInt(id1, 10),
-        id2: parseInt(id2, 10),
-        gadm: '2.8'
+        id2: `${iso.toUpperCase()}.${parseInt(id1, 10)}.${parseInt(id2, 10)}_1`
       };
 
       logger.debug('Checking existing admin2 geostore');
-      let existingGeo = yield GeoStoreService.getGeostoreByInfo(params);
+      let existingGeo = yield GeoStoreServiceV2.getGeostoreByInfo(params);
       logger.debug('Existed geo', existingGeo);
       if (existingGeo) {
         logger.debug('Return admin2 geojson stored');
@@ -184,9 +180,14 @@ class CartoDBService {
         let result = data.rows[0];
         logger.debug('Saving admin2 geostore');
         const geoData = {
-          info: params
+            info: {
+                iso: iso.toUpperCase(),
+                id1: parseInt(id1, 10),
+                id2: parseInt(id2, 10),
+                gadm: '3.6'
+            }
         };
-        existingGeo = yield GeoStoreService.saveGeostore(JSON.parse(result.geojson), geoData);
+        existingGeo = yield GeoStoreServiceV2.saveGeostore(JSON.parse(result.geojson), geoData);
         return existingGeo;
       }
       return null;
@@ -204,7 +205,7 @@ class CartoDBService {
         };
 
         logger.debug('Checking existing use geo', info);
-        let existingGeo = yield GeoStoreService.getGeostoreByInfo(info);
+        let existingGeo = yield GeoStoreServiceV2.getGeostoreByInfo(info);
         logger.debug('Existed geo', existingGeo);
         if (existingGeo) {
           logger.debug('Return use geojson stored');
@@ -220,7 +221,7 @@ class CartoDBService {
             const geoData = {
               info : info
             };
-            existingGeo = yield GeoStoreService.saveGeostore(JSON.parse(result.geojson), geoData);
+            existingGeo = yield GeoStoreServiceV2.saveGeostore(JSON.parse(result.geojson), geoData);
             logger.debug('Return use geojson from carto');
             return existingGeo;
         }
@@ -235,7 +236,7 @@ class CartoDBService {
         };
 
         logger.debug('Checking existing wdpa geo');
-        let existingGeo = yield GeoStoreService.getGeostoreByInfo(params);
+        let existingGeo = yield GeoStoreServiceV2.getGeostoreByInfo(params);
         logger.debug('Existed geo', existingGeo);
         if (existingGeo) {
           logger.debug('Return wdpa geojson stored');
@@ -250,7 +251,7 @@ class CartoDBService {
             const geoData = {
               info : params
             };
-            existingGeo = yield GeoStoreService.saveGeostore(JSON.parse(result.geojson), geoData);
+            existingGeo = yield GeoStoreServiceV2.saveGeostore(JSON.parse(result.geojson), geoData);
             logger.debug('Return wdpa geojson from carto');
             return existingGeo;
         }
@@ -277,4 +278,4 @@ class CartoDBService {
     }
 }
 
-module.exports = new CartoDBService();
+module.exports = new CartoDBServiceV2();

--- a/app/src/services/cartoDBServiceV2.js
+++ b/app/src/services/cartoDBServiceV2.js
@@ -11,7 +11,7 @@ const ISO = `SELECT ST_AsGeoJSON(st_makevalid(the_geom)) AS geojson, (ST_Area(ge
         FROM gadm36_adm0
         WHERE gid_0 = UPPER('{{iso}}')`;
 
-const ISO_NAME = `SELECT iso, name_0 as name
+const ISO_NAME = `SELECT gid_0, name_0 as name
         FROM gadm36_adm0
         WHERE gid_0 in `;
 

--- a/app/src/services/coverageServiceV2.js
+++ b/app/src/services/coverageServiceV2.js
@@ -1,0 +1,146 @@
+'use strict';
+var logger = require('logger');
+var CoverageDuplicated = require('errors/coverageDuplicated');
+var CoverageNotFound = require('errors/coverageNotFound');
+var CartoDB = require('cartodb');
+var Mustache = require('mustache');
+var config = require('config');
+
+const ISO = `with c as (select the_geom_webmercator, st_area(the_geom_webmercator)/10000 as area_ha from gadm36_adm0 where iso = UPPER('{{iso}}')),
+            cl as (select (st_buffer(st_simplify(the_geom_webmercator,10000),1)) the_geom_webmercator, slug, coverage_slug from coverage_layers)
+            SELECT slug FROM  cl inner join c on ST_INTERSECTS(c.the_geom_webmercator, cl.the_geom_webmercator)
+            where (((st_area(ST_intersection(c.the_geom_webmercator, cl.the_geom_webmercator))/10000)::numeric/area_ha::numeric)*100)>1`;
+
+const ID1 = `with c as (select the_geom_webmercator, st_area(the_geom_webmercator)/10000 as area_ha from gadm36_adm1 where iso = UPPER('{{iso}}') AND id_1 = {{id1}}),
+            cl as (select (st_buffer(st_simplify(the_geom_webmercator,10000),1)) the_geom_webmercator, slug, coverage_slug from coverage_layers)
+            SELECT slug FROM  cl inner join c on ST_INTERSECTS(c.the_geom_webmercator, cl.the_geom_webmercator)
+            where (((st_area(ST_intersection(c.the_geom_webmercator, cl.the_geom_webmercator))/10000)::numeric/area_ha::numeric)*100)>1`;
+
+const WDPA = `with p as (SELECT p.the_geom AS the_geom
+        FROM (
+          SELECT CASE
+          WHEN marine::numeric = 2 THEN NULL
+            WHEN ST_NPoints(the_geom)<=18000 THEN the_geom
+            WHEN ST_NPoints(the_geom) BETWEEN 18000 AND 50000 THEN ST_RemoveRepeatedPoints(the_geom, 0.001)
+            ELSE ST_RemoveRepeatedPoints(the_geom, 0.005)
+            END AS the_geom
+          FROM wdpa_protected_areas
+          WHERE wdpaid={{wdpaid}}
+      ) p)
+        SELECT slug from coverage_layers cl, p where ST_INTERSECTS(cl.the_geom, p.the_geom) `;
+
+const USE = `SELECT slug FROM coverage_layers cl, {{useTable}} c where c.cartodb_id = {{pid}} and ST_INTERSECTS(cl.the_geom, c.the_geom)`;
+
+
+const COVERAGES = `SELECT ST_AsGeoJSON(the_geom) as geojson, coverage_slug as slug, slug as layerSlug from coverage_layers`;
+
+const WORLD = `SELECT slug FROM coverage_layers where ST_INTERSECTS(the_geom, ST_SetSRID(ST_GeomFromGeoJSON('{{{geojson}}}'), 4326))`;
+const REDUCED_WORLD = `with p as (SELECT slug, the_geom FROM coverage_layers {{{filter}}}) SELECT slug FROM p  where ST_INTERSECTS(the_geom, ST_SetSRID(ST_GeomFromGeoJSON('{{{geojson}}}'), 4326))`;
+
+
+var executeThunk = function(client, sql, params) {
+  return function(callback) {
+    client.execute(sql, params).done(function(data) {
+      callback(null, data);
+    }).error(function(err) {
+      callback(err[0], null);
+    });
+  };
+};
+
+
+class CoverageServiceV2 {
+
+  constructor() {
+    this.client = new CartoDB.SQL({
+      user: config.get('cartoDB.user')
+    });
+  }
+
+  *
+  getNational(iso) {
+    logger.debug('Obtaining national of iso %s', iso);
+    let params = {
+      iso: iso
+    };
+
+    let data = yield executeThunk(this.client, ISO, params);
+    if (data.rows && data.rows.length > 0) {
+      return data.rows.map(item => item.slug);
+    }
+    return [];
+  }
+
+  *
+  getSubnational(iso, id1) {
+    logger.debug('Obtaining subnational of iso %s and id1', iso, id1);
+    let params = {
+      iso: iso,
+      id1: id1
+    };
+
+    let data = yield executeThunk(this.client, ID1, params);
+    if (data.rows && data.rows.length > 0) {
+      return data.rows.map(item => item.slug);
+    }
+    return [];
+  }
+
+  *
+  getUse(useTable, id) {
+    logger.debug('Obtaining use with id %s', id);
+
+    let params = {
+      useTable: useTable,
+      pid: id
+    };
+
+    let data = yield executeThunk(this.client, USE, params);
+
+    if (data.rows && data.rows.length > 0) {
+      return data.rows.map(item => item.slug);
+    }
+    return [];
+  }
+
+  *
+  getWdpa(wdpaid) {
+    logger.debug('Obtaining wpda of id %s', wdpaid);
+
+    let params = {
+      wdpaid: wdpaid
+    };
+
+    let data = yield executeThunk(this.client, WDPA, params);
+    if (data.rows && data.rows.length > 0) {
+      return data.rows.map(item => item.slug);
+    }
+    return [];
+  }
+
+  *
+  getCoverages() {
+    logger.info('Getting coverages');
+
+    let data = yield executeThunk(this.client, COVERAGES);
+    return data;
+  }
+
+  *
+  getWorld(geojson, { slugs }) {
+    logger.info('Getting layers that intersect');
+
+    let params = {
+      geojson: JSON.stringify(geojson),
+      filter: slugs && slugs.length && `WHERE slug IN (${slugs.map(slug => `'${slug.trim()}'`).join(',')})`
+    };
+    const query = slugs ? REDUCED_WORLD : WORLD;
+    let data = yield executeThunk(this.client, query, params);
+    if (data.rows && data.rows.length > 0) {
+      return data.rows.map(item => item.slug);
+    }
+    return [];
+  }
+}
+
+module.exports = new CoverageServiceV2();

--- a/app/src/services/geoStoreServiceV2.js
+++ b/app/src/services/geoStoreServiceV2.js
@@ -1,0 +1,206 @@
+'use strict';
+var logger = require('logger');
+var GeoStore = require('models/geoStore');
+var GeoJSONConverter = require('converters/geoJSONConverter');
+var md5 = require('md5');
+var CartoDB = require('cartodb');
+var IdConnection = require('models/idConnection');
+var turf = require('turf');
+var ProviderNotFound = require('errors/providerNotFound');
+var GeoJSONNotFound = require('errors/geoJSONNotFound');
+var config = require('config');
+
+const CARTO_PROVIDER = 'carto';
+
+
+var executeThunk = function(client, sql, params) {
+    return function(callback) {
+        client.execute(sql, params).done(function(data) {
+            callback(null, data);
+        }).error(function(err) {
+            callback(err[0], null);
+        });
+    };
+};
+
+
+class GeoStoreServiceV2 {
+
+    static * repairGeometry(geojson) {
+        logger.debug('Repair geoJSON geometry');
+        logger.debug('Generating query');
+        let sql = `SELECT ST_AsGeoJson(ST_CollectionExtract(st_MakeValid(ST_GeomFromGeoJSON('${JSON.stringify(geojson)}')),3)) as geojson`;
+        logger.debug('SQL to repair geojson: %s', sql);
+        try {
+            let client = new CartoDB.SQL({
+                user: config.get('cartoDB.user')
+            });
+            let data = yield executeThunk(client, sql, {});
+            if (data.rows && data.rows.length === 1) {
+                data.rows[0].geojson = JSON.parse(data.rows[0].geojson);
+                logger.debug(data.rows[0].geojson);
+                return data.rows[0];
+            }
+            throw new GeoJSONNotFound('No Geojson returned');
+        }
+        catch(e) {
+            logger.error(e);
+            throw e;
+        }
+    }
+    
+    static * obtainGeoJSONOfCarto(table, user, filter) {
+        logger.debug('Obtaining geojson with params: table %s, user %s, filter %s', table, user, filter);
+        logger.debug('Generating query');
+        let sql = `SELECT ST_AsGeoJson(the_geom) as geojson, (ST_Area(geography(the_geom))/10000) as area_ha FROM ${table} WHERE ${filter}`;
+        logger.debug('SQL to obtain geojson: %s', sql);
+        let client = new CartoDB.SQL({
+            user: user
+        });
+        let data = yield executeThunk(client, sql, {});
+        if (data.rows && data.rows.length === 1) {
+            data.rows[0].geojson = JSON.parse(data.rows[0].geojson);
+            logger.debug(data.rows[0].geojson);
+            return data.rows[0];
+        }
+        throw new GeoJSONNotFound('Geojson not found');
+    }
+
+    static * getNewHash(hash){
+        let idCon = yield IdConnection.findOne({oldId: hash}).exec();
+        if(!idCon){
+            return hash;
+        }
+        return idCon.hash;
+    }
+
+    static * getGeostoreById(id){
+        logger.debug(`Getting geostore by id ${id}`);
+        let hash = yield GeoStoreServiceV2.getNewHash(id);
+        logger.debug('hash',hash);
+        let geoStore = yield GeoStore.findOne({hash: hash}, {'geojson._id': 0, 'geojson.features._id': 0});
+        if (geoStore){
+          logger.debug('geostore', JSON.stringify(geoStore.geojson));
+          return geoStore;
+        }
+        return null;
+    }
+
+    static * getNationalList(){
+        logger.debug('Obtaining national list from database');
+        const query = {
+            'info.iso': { $ne:  null },
+            'info.id1': null
+        };
+        const select = 'hash info.iso';
+        return yield GeoStore.find(query, select);
+    }
+
+    static * getGeostoreByInfoProps(infoQuery){
+        const geoStore = yield GeoStore.findOne(infoQuery);
+        return geoStore;
+    }
+
+    static * getGeostoreByInfo(info){
+      const geoStore = yield GeoStore.findOne({info});
+      return geoStore;
+    }
+
+    static * obtainGeoJSON(provider) {
+        logger.debug('Obtaining geojson of provider', provider);
+        switch (provider.type) {
+            case CARTO_PROVIDER:
+                return yield GeoStoreServiceV2.obtainGeoJSONOfCarto(provider.table, provider.user, provider.filter);
+            default:
+                logger.error('Provider not found');
+                throw new ProviderNotFound(`Provider ${provider.type} not found`);
+        }
+    }
+
+    static * calculateBBox(geoStore){
+        logger.debug('Calculating bbox');
+        geoStore.bbox = turf.bbox(geoStore.geojson);
+        yield geoStore.save();
+        return geoStore;
+    }
+
+    static * saveGeostore(geojson, data) {
+
+        let geoStore = {
+            geojson: geojson
+        };
+
+        if (data && data.provider) {
+          let geoJsonObtained = yield GeoStoreServiceV2.obtainGeoJSON(data.provider);
+          geoStore.geojson = geoJsonObtained.geojson;
+          geoStore.areaHa = geoJsonObtained.area_ha;
+          geoStore.provider = {
+              type: data.provider.type,
+              table: data.provider.table,
+              user: data.provider.user,
+              filter: data.provider.filter
+          };
+        }
+        if (data && data.info) {
+          geoStore.info = data.info;
+        }
+        geoStore.lock = data.lock || false;
+        
+        logger.debug('Fix and convert geojson');
+        logger.debug('Converting', JSON.stringify(geoStore.geojson));
+        
+        let geoJsonObtained = yield GeoStoreServiceV2.repairGeometry(GeoJSONConverter.getGeometry(geoStore.geojson));
+        geoStore.geojson = geoJsonObtained.geojson;
+        
+        logger.debug('Repaired geometry', JSON.stringify(geoStore.geojson));
+        logger.debug('Make Feature Collection');
+        geoStore.geojson = GeoJSONConverter.makeFeatureCollection(geoStore.geojson);
+        logger.debug('Result', JSON.stringify(geoStore.geojson));
+        logger.debug('Creating hash from geojson md5');
+        geoStore.hash = md5(JSON.stringify(geoStore.geojson));
+        if (geoStore.areaHa === undefined) {
+            geoStore.areaHa = turf.area(geoStore.geojson) / 10000; // convert to ha2
+        }
+        let exist = yield GeoStore.findOne({
+            hash: geoStore.hash
+        });
+        if(!geoStore.bbox) {
+            geoStore.bbox = turf.bbox(geoStore.geojson);
+        }
+        
+        yield GeoStore.findOneAndUpdate({hash: geoStore.hash}, geoStore, {upsert: true, new: true, runValidators: true});
+        
+        return yield GeoStore.findOne({
+            hash: geoStore.hash
+        }, {
+            'geojson._id': 0,
+            'geojson.features._id': 0
+        });
+    }
+
+    static * calculateArea(geojson, data) {
+
+        let geoStore = {
+            geojson: geojson
+        };
+
+        if (data && data.provider) {
+          let geoJsonObtained = yield GeoStoreServiceV2.obtainGeoJSON(data.provider);
+          geoStore.geojson = geoJsonObtained.geojson;
+          geoStore.areaHa = geoJsonObtained.area_ha;
+        }
+
+        logger.debug('Converting geojson');
+        logger.debug('Converting', JSON.stringify(geoStore.geojson));
+        geoStore.geojson = GeoJSONConverter.convert(geoStore.geojson);
+        logger.debug('Result', JSON.stringify(geoStore.geojson));
+        geoStore.areaHa = turf.area(geoStore.geojson) / 10000; // convert to ha2
+        geoStore.bbox = turf.bbox(geoStore.geojson);
+
+        return yield geoStore;
+
+    }
+
+}
+
+module.exports = GeoStoreServiceV2;


### PR DESCRIPTION
## Overview

Adds a version 2 router to the microservice which utilises the GAMD 3.6 CARTO tables (`gadm36_adm0`, `gadm36_adm1`, and `gadm36_adm2`).

Also updates microservice response to include the key `data.info.gadm`, which returns information about the version in use (v1 = 2.8, v2 = 3.6).

``` json
{
    "data": {
        "type": "geoStore",
        "id": "5fe3e75d15a1a334a7cf53940d005d06",
        "attributes": {
            "geojson": {
                "features": [],
                "crs": {},
                "type": "FeatureCollection"
            },
            "hash": "5fe3e75d15a1a334a7cf53940d005d06",
            "provider": {},
            "areaHa": 439961.1783324665,
            "bbox": [
                -69.7218780517578,
                -11.0237398147582,
                -68.5499725341797,
                -10.4889497756958
            ],
            "lock": false,
            "info": {
                "use": {},
                "iso": "BRA",
                "id1": 1,
                "id2": 3,
                "gadm": "3.6"
            }
        }
    }
}
```

## Testing

Requires thorough testing of all v2 endpoints before merging!