### PR TITLE
[FEATURE] Adds 'simplify' argument to admin endpoints

### DIFF
--- a/app/src/routes/api/v2/geoStoreRouter.js
+++ b/app/src/routes/api/v2/geoStoreRouter.js
@@ -107,7 +107,11 @@ class GeoStoreRouterV2 {
 
     static * getNational() {
         logger.info('Obtaining national data geojson (GADM v3.6)');
-        const data = yield CartoServiceV2.getNational(this.params.iso);
+        const thresh = parseFloat(this.query.simplify) || null;
+        if(thresh && (thresh > 1 || thresh <= 0)) {
+            this.throw(404, 'Bad threshold for simplify');
+        }
+        const data = yield CartoServiceV2.getNational(this.params.iso, thresh);
         if (!data) {
           this.throw(404, 'Country not found');
         }
@@ -125,16 +129,24 @@ class GeoStoreRouterV2 {
 
     static * getSubnational() {
         logger.info('Obtaining subnational data geojson (GADM v3.6)');
-        const data = yield CartoServiceV2.getSubnational(this.params.iso, this.params.id1);
+        const thresh = parseFloat(this.query.simplify) || null;
+        if(thresh && (thresh > 1 || thresh <= 0)) {
+            this.throw(404, 'Bad threshold for simplify');
+        }
+        const data = yield CartoServiceV2.getSubnational(this.params.iso, this.params.id1, thresh);
         if (!data) {
-          this.throw(404, 'Country/Region not found');
+          
         }
         this.body = GeoJSONSerializer.serialize(data);
     }
 
     static * getAdmin2() {
         logger.info('Obtaining Admin2 data geojson (GADM v3.6)');
-        const data = yield CartoServiceV2.getAdmin2(this.params.iso, this.params.id1, this.params.id2);
+        const thresh = parseFloat(this.query.simplify) || null;
+        if(thresh && (thresh > 1 || thresh <= 0)) {
+            this.throw(404, 'Bad threshold for simplify');
+        }
+        const data = yield CartoServiceV2.getAdmin2(this.params.iso, this.params.id1, this.params.id2, thresh);
         if (!data) {
           this.throw(404, 'Country/Admin1/Admin2 not found');
         }

--- a/app/src/services/cartoDBService.js
+++ b/app/src/services/cartoDBService.js
@@ -165,8 +165,7 @@ class CartoDBService {
       let params = {
         iso: iso.toUpperCase(),
         id1: parseInt(id1, 10),
-        id2: parseInt(id2, 10),
-        gadm: '2.8'
+        id2: parseInt(id2, 10)
       };
 
       logger.debug('Checking existing admin2 geostore');
@@ -184,7 +183,8 @@ class CartoDBService {
         let result = data.rows[0];
         logger.debug('Saving admin2 geostore');
         const geoData = {
-          info: params
+          info: params,
+          gadm: '2.8'
         };
         existingGeo = yield GeoStoreService.saveGeostore(JSON.parse(result.geojson), geoData);
         return existingGeo;

--- a/app/src/services/geoStoreService.js
+++ b/app/src/services/geoStoreService.js
@@ -168,9 +168,7 @@ class GeoStoreService {
             geoStore.bbox = turf.bbox(geoStore.geojson);
         }
 
-
         yield GeoStore.findOneAndUpdate({hash: geoStore.hash}, geoStore, {upsert: true, new: true, runValidators: true});
-
         
         return yield GeoStore.findOne({
             hash: geoStore.hash


### PR DESCRIPTION
Some large geometries time out when retrieving from the GAMD3.6 tables (since they use higher res polygons).

This adds an argument in the url which, when included, can simplify the geometry using some arbitrary threshold in order to return a lighter geojson. Note that in these cases the geostore isn't saved against the admin (iso/amd1/adm2) ids.

e.g. `.../geostore/admin/IDN/23?simplify=0.01` will return the Papua, Indonesia polygon with a threshold of 0.01.

Simplify values must be greater than 0 and less than or equal to 0.1.
