### PR TITLE
Improve Simplify kwarg

### DIFF
--- a/app/src/models/geoStore.js
+++ b/app/src/models/geoStore.js
@@ -41,7 +41,10 @@ var GeoStore = new Schema({
         use: {
             use:{type: String, required: false},
             id:{type: Number, required: false},
-        }
+        },
+        simplify: {type: Boolean, required: false},
+        simplifyThresh: {type: Number, required: false}
+
     }
 });
 

--- a/app/src/routes/api/v2/coverageRouter.js
+++ b/app/src/routes/api/v2/coverageRouter.js
@@ -36,7 +36,7 @@ class CoverageRouterV2 {
         useTable = 'gfw_logging';
         break;
       default:
-        this.throw(400, 'Name param invalid');
+        useTable = this.params.name;
     }
     let result = yield CoverageServiceV2.getUse(useTable, this.params.id);
     this.body = CoverageSerializer.serialize({

--- a/app/src/routes/api/v2/geoStoreRouter.js
+++ b/app/src/routes/api/v2/geoStoreRouter.js
@@ -107,9 +107,13 @@ class GeoStoreRouterV2 {
 
     static * getNational() {
         logger.info('Obtaining national data geojson (GADM v3.6)');
-        const thresh = parseFloat(this.query.simplify) || null;
-        if(thresh && (thresh > 1 || thresh <= 0)) {
-            this.throw(404, 'Bad threshold for simplify');
+        let thresh = this.query.simplify ? JSON.parse(this.query.simplify) : null;
+
+        if(thresh && typeof thresh === Number && (thresh > 1 || thresh <= 0)){
+                this.throw(404, 'Bad threshold for simplify. Must be in range 0-1.');
+        }
+        else if (thresh && typeof thresh === Boolean && thresh !== true) {
+            this.throw(404, 'Bad syntax for simplify. Must be "true".');
         }
         const data = yield CartoServiceV2.getNational(this.params.iso, thresh);
         if (!data) {
@@ -129,9 +133,13 @@ class GeoStoreRouterV2 {
 
     static * getSubnational() {
         logger.info('Obtaining subnational data geojson (GADM v3.6)');
-        const thresh = parseFloat(this.query.simplify) || null;
-        if(thresh && (thresh > 1 || thresh <= 0)) {
-            this.throw(404, 'Bad threshold for simplify');
+        let thresh = this.query.simplify ? JSON.parse(this.query.simplify) : null;
+
+        if(thresh && typeof thresh === Number && (thresh > 1 || thresh <= 0)){
+                this.throw(404, 'Bad threshold for simplify. Must be in range 0-1.');
+        }
+        else if (thresh && typeof thresh === Boolean && thresh !== true) {
+            this.throw(404, 'Bad syntax for simplify. Must be "true".');
         }
         const data = yield CartoServiceV2.getSubnational(this.params.iso, this.params.id1, thresh);
         if (!data) {
@@ -140,13 +148,17 @@ class GeoStoreRouterV2 {
         this.body = GeoJSONSerializer.serialize(data);
     }
 
-    static * getAdmin2() {
+    static * getRegional() {
         logger.info('Obtaining Admin2 data geojson (GADM v3.6)');
-        const thresh = parseFloat(this.query.simplify) || null;
-        if(thresh && (thresh > 1 || thresh <= 0)) {
-            this.throw(404, 'Bad threshold for simplify');
+        let thresh = this.query.simplify ? JSON.parse(this.query.simplify) : null;
+
+        if(thresh && typeof thresh === Number && (thresh > 1 || thresh <= 0)){
+                this.throw(404, 'Bad threshold for simplify. Must be in range 0-1.');
         }
-        const data = yield CartoServiceV2.getAdmin2(this.params.iso, this.params.id1, this.params.id2, thresh);
+        else if (thresh && typeof thresh === Boolean && thresh !== true) {
+            this.throw(404, 'Bad syntax for simplify. Must be "true".');
+        }
+        const data = yield CartoServiceV2.getRegional(this.params.iso, this.params.id1, this.params.id2, thresh);
         if (!data) {
           this.throw(404, 'Country/Admin1/Admin2 not found');
         }
@@ -155,6 +167,11 @@ class GeoStoreRouterV2 {
 
     static * use() {
         logger.info('Obtaining use data with name %s and id %s', this.params.name, this.params.id);
+        let thresh = this.query.simplify ? JSON.parse(this.query.simplify) : null;
+        if (thresh && typeof thresh === Boolean && thresh !== true) {
+            this.throw(404, 'Bad syntax for simplify. Must be "true".');
+        }
+
         let useTable = null;
         switch (this.params.name) {
             case 'mining':
@@ -169,9 +186,6 @@ class GeoStoreRouterV2 {
             case 'logging':
                 useTable = 'gfw_logging';
                 break;
-            case 'endemic_bird_areas':
-                useTable = 'endemic_bird_areas';
-                break;
             case 'tiger_conservation_landscapes':
                 useTable = 'tcl';
                 break;
@@ -181,7 +195,7 @@ class GeoStoreRouterV2 {
         if (!useTable) {
             this.throw(404, 'Name not found');
         }
-        const data = yield CartoServiceV2.getUse(useTable, this.params.id);
+        const data = yield CartoServiceV2.getUse(useTable, this.params.id, thresh);
         if (!data) {
           this.throw(404, 'Use not found');
         }
@@ -190,7 +204,6 @@ class GeoStoreRouterV2 {
 
     static * wdpa() {
         logger.info('Obtaining wpda data with id %s', this.params.id);
-
         const data = yield CartoServiceV2.getWdpa(this.params.id);
         if (!data) {
           this.throw(404, 'Wdpa not found');
@@ -229,7 +242,7 @@ router.post('/area', GeoStoreValidator.create, GeoStoreRouterV2.getArea);
 router.get('/admin/:iso', GeoStoreRouterV2.getNational);
 router.get('/admin/list', GeoStoreRouterV2.getNationalList);
 router.get('/admin/:iso/:id1', GeoStoreRouterV2.getSubnational);
-router.get('/admin/:iso/:id1/:id2', GeoStoreRouterV2.getAdmin2);
+router.get('/admin/:iso/:id1/:id2', GeoStoreRouterV2.getRegional);
 router.get('/use/:name/:id', GeoStoreRouterV2.use);
 router.get('/wdpa/:id', GeoStoreRouterV2.wdpa);
 router.get('/:hash/view', GeoStoreRouterV2.view);

--- a/app/src/services/cartoDBServiceV2.js
+++ b/app/src/services/cartoDBServiceV2.js
@@ -39,6 +39,18 @@ const USE = `SELECT ST_AsGeoJSON(st_makevalid(the_geom)) AS geojson, (ST_Area(ge
         FROM {{use}}
         WHERE cartodb_id = {{id}}`;
 
+const SIMPLIFIED_USE = 
+        `SELECT ST_Area(geography(the_geom))/10000 as area_ha, the_geom,
+        CASE
+            WHEN area_ha::numeric > 1e8 
+            THEN st_asgeojson(st_makevalid(st_simplify(the_geom, 0.05)))
+            WHEN area_ha::numeric > 1e6 
+            THEN st_asgeojson(st_makevalid(st_simplify(the_geom, 0.005)))
+            ELSE st_asgeojson(st_makevalid(the_geom))
+        END AS geojson
+        FROM {{use}}
+        WHERE cartodb_id = {{id}}`;
+
 const executeThunk = function(client, sql, params, thresh) {
     return function(callback) {
         sql = sql.replace('{geom}', thresh ? `ST_Simplify(the_geom, ${thresh})` : 'the_geom')
@@ -58,6 +70,17 @@ const deserializer = function(obj) {
     };
 };
 
+var parseSimplifyGeom = function(iso, id1, id2) {
+    const bigCountries = ['USA', 'RUS', 'CAN', 'CHN', 'BRA', 'IDN'];
+    let baseThresh = bigCountries.includes(iso) ? 0.05 : 0.005;
+    if(iso && !id1 && !id2){
+        return baseThresh;
+    }
+    else {
+        return id1 && !id2 ? baseThresh / 100 : baseThresh / 100;
+    }
+  };
+
 
 class CartoDBServiceV2 {
 
@@ -68,19 +91,25 @@ class CartoDBServiceV2 {
     }
 
     * getNational(iso, thresh) {
-        logger.debug('Obtaining national of iso %s', iso);
+        logger.debug('Request %s to carto', iso);
         let params = {
             'iso': iso.toUpperCase()
         };
+
+        const simplifyThresh = parseSimplifyGeom(iso);
+
+        if(thresh === true) {
+            thresh = simplifyThresh;
+        }
+
         logger.debug('Checking existing national geo');
-        let existingGeo = yield GeoStoreServiceV2.getGeostoreByInfoProps(params);
+        let existingGeo = yield GeoStoreServiceV2.getGeostoreByInfoProps({iso, simplifyThresh: thresh});
         logger.debug('Existed geo', existingGeo);
-        if (existingGeo && !thresh) {
+        if (existingGeo) {
           logger.debug('Return national geojson stored');
           return existingGeo;
         }
 
-        logger.debug('Request national to carto');
         let data = yield executeThunk(this.client, ISO, params, thresh);
         if (data.rows && data.rows.length > 0) {
           let result = data.rows[0];
@@ -89,7 +118,8 @@ class CartoDBServiceV2 {
             info : {
                 iso: iso.toUpperCase(),
                 name: result.name,
-                gadm: '3.6'
+                gadm: '3.6',
+                simplifyThresh
             }
           };
           existingGeo = yield GeoStoreServiceV2.saveGeostore(JSON.parse(result.geojson), geoData);
@@ -132,10 +162,16 @@ class CartoDBServiceV2 {
       let params = {
         id1: `${iso.toUpperCase()}.${parseInt(id1, 10)}_1`
       };
+
+      const simplifyThresh = parseSimplifyGeom(iso, id1);
+      if(thresh === true) {
+          thresh = simplifyThresh;
+      }
+
       logger.debug('Checking existing subnational geo');
-      let existingGeo = yield GeoStoreServiceV2.getGeostoreByInfo({iso, id1});
+      let existingGeo = yield GeoStoreServiceV2.getGeostoreByInfo({iso, id1, simplifyThresh});
       logger.debug('Existed geo', existingGeo);
-      if (existingGeo && !thresh) {
+      if (existingGeo) {
         logger.debug('Return subnational geojson stored');
         return existingGeo;
       }
@@ -151,7 +187,8 @@ class CartoDBServiceV2 {
               iso: iso.toUpperCase(),
               name: result.name,
               id1: parseInt(id1, 10),
-              gadm: '3.6'
+              gadm: '3.6',
+              simplifyThresh
           }
         };
         existingGeo = yield GeoStoreServiceV2.saveGeostore(JSON.parse(result.geojson), geoData);
@@ -160,14 +197,19 @@ class CartoDBServiceV2 {
       return null;
     }
 
-    * getAdmin2(iso, id1, id2, thresh) {
+    * getRegional(iso, id1, id2, thresh) {
       logger.debug('Obtaining admin2 of iso %s, id1 and id2', iso, id1, id2);
       let params = {
         id2: `${iso.toUpperCase()}.${parseInt(id1, 10)}.${parseInt(id2, 10)}_1`
       };
 
+      const simplifyThresh = parseSimplifyGeom(iso, id1, id2);
+      if(thresh === true) {
+          thresh = simplifyThresh;
+      }
+
       logger.debug('Checking existing admin2 geostore');
-      let existingGeo = yield GeoStoreServiceV2.getGeostoreByInfo({iso, id1, id2});
+      let existingGeo = yield GeoStoreServiceV2.getGeostoreByInfo({iso, id1, id2, simplifyThresh});
       logger.debug('Existed geo', existingGeo);
       if (existingGeo && !thresh) {
         logger.debug('Return admin2 geojson stored');
@@ -186,7 +228,8 @@ class CartoDBServiceV2 {
                 id1: parseInt(id1, 10),
                 id2: parseInt(id2, 10),
                 name: result.name,
-                gadm: '3.6'
+                gadm: '3.6',
+                simplifyThresh
             }
         };
         existingGeo = yield GeoStoreServiceV2.saveGeostore(JSON.parse(result.geojson), geoData);
@@ -195,15 +238,15 @@ class CartoDBServiceV2 {
       return null;
     }
 
-    * getUse(use, id) {
+    * getUse(use, id, thresh) {
         logger.debug('Obtaining use with id %s', id);
-
         let params = {
           use: use,
           id: parseInt(id, 10)
         };
         let info = {
-          use: params
+          use: params,
+          simplify: thresh ? true : false
         };
 
         logger.debug('Checking existing use geo', info);
@@ -214,8 +257,10 @@ class CartoDBServiceV2 {
           return existingGeo;
         }
 
+        const USE_SQL = thresh ? SIMPLIFIED_USE : USE;
+
         logger.debug('Request use to carto');
-        let data = yield executeThunk(this.client, USE, params);
+        let data = yield executeThunk(this.client, USE_SQL, params);
 
         if (data.rows && data.rows.length > 0) {
             let result = data.rows[0];


### PR DESCRIPTION
# Overview

Previously the simplify kwarg applied only to the admin endpoints, allowing you to arbitrarily specify the simplification threshold (where 0 < thresh < 1) used when requesting shapes from carto.

e.g.  `geostore/admin/BRA?simplify=0.005`

would apply `ST_Simplify(the_geom, 0.005)` to the carto request.

### New functionality

This update allows users to also apply `simplify` to the `geostore/use` endpoint. Note that we did not apply to wdpa's, since they tend to be very small/simple shapes.

In addition, this also adds the ability to specify `?simplify=true` for both the _use_ and _admin_ endpoints. This makes an automatic guess (based on the geom size for now) and simplifies accordingly.