### PR TITLE
Allow geostore without props

### DIFF
--- a/app/src/services/geoStoreService.js
+++ b/app/src/services/geoStoreService.js
@@ -164,17 +164,17 @@ class GeoStoreService {
                 filter: data.provider.filter
             };
         }
-        let props = null;
+        let props = {};
         const geom_type = geoStore.geojson.type || null;
         if (geom_type && geom_type === "FeatureCollection") {
             logger.info('Preserving FeatureCollection properties.')
-            props = geoStore.geojson.features[0].properties || null;
+            props = geoStore.geojson.features[0].properties || {};
         } else if(geom_type && geom_type === "Feature"){
             logger.info('Preserving Feature properties.')
-            props = geoStore.geojson.properties || null;
+            props = geoStore.geojson.properties || {};
         } else{
             logger.info('Preserving Geometry properties.')
-            props = geoStore.geojson.properties || null;
+            props = geoStore.geojson.properties || {};
         }
         logger.debug('Props', JSON.stringify(props));
         if (data && data.info) {

--- a/app/src/services/geoStoreServiceV2.js
+++ b/app/src/services/geoStoreServiceV2.js
@@ -167,17 +167,17 @@ class GeoStoreServiceV2 {
                 filter: data.provider.filter
             };
         }
-        let props = null;
+        let props = {};
         const geom_type = geoStore.geojson.type || null;
         if (geom_type && geom_type === "FeatureCollection") {
             logger.info('Preserving FeatureCollection properties.')
-            props = geoStore.geojson.features[0].properties || null;
+            props = geoStore.geojson.features[0].properties || {};
         } else if(geom_type && geom_type === "Feature"){
             logger.info('Preserving Feature properties.')
-            props = geoStore.geojson.properties || null;
+            props = geoStore.geojson.properties || {};
         } else{
             logger.info('Preserving Geometry properties.')
-            props = geoStore.geojson.properties || null;
+            props = geoStore.geojson.properties || {};
         }
         logger.debug('Props', JSON.stringify(props));
         if (data && data.info) {


### PR DESCRIPTION
Currently if a geometry has no properties a POST request will fail (geometry must have properties).

This small fix allows no properties to be posted, adding an empty key `properties: {}` to the geostore entity.