### PR TITLE
Add more stringent mongodb check fo getNational and getSubnational

### DIFF
--- a/app/src/services/cartoDBService.js
+++ b/app/src/services/cartoDBService.js
@@ -72,7 +72,8 @@ class CartoDBService {
         logger.debug('Obtaining national of iso %s', iso);
         const query = {
             'info.iso': iso.toUpperCase(),
-            'info.id1': null
+            'info.id1': null,
+            'info.id2': null
         };
         logger.debug('Checking existing national geo');
         let existingGeo = yield GeoStoreService.getGeostoreByInfoProps(query);
@@ -129,7 +130,8 @@ class CartoDBService {
         logger.debug('Obtaining subnational of iso %s and id1', iso, id1);
         const params = {
             iso: iso.toUpperCase(),
-            id1: parseInt(id1, 10)
+            id1: parseInt(id1, 10),
+            id2: null
         };
 
         logger.debug('Checking existing subnational geo');

--- a/app/src/services/cartoDBService.js
+++ b/app/src/services/cartoDBService.js
@@ -71,9 +71,7 @@ class CartoDBService {
     * getNational(iso) {
         logger.debug('Obtaining national of iso %s', iso);
         const query = {
-            'info.iso': iso.toUpperCase(),
-            'info.id1': null,
-            'info.id2': null
+            'info.iso': iso.toUpperCase()
         };
         logger.debug('Checking existing national geo');
         let existingGeo = yield GeoStoreService.getGeostoreByInfoProps(query);
@@ -130,8 +128,7 @@ class CartoDBService {
         logger.debug('Obtaining subnational of iso %s and id1', iso, id1);
         const params = {
             iso: iso.toUpperCase(),
-            id1: parseInt(id1, 10),
-            id2: null
+            id1: parseInt(id1, 10)
         };
 
         logger.debug('Checking existing subnational geo');

--- a/app/src/services/cartoDBServiceV2.js
+++ b/app/src/services/cartoDBServiceV2.js
@@ -99,7 +99,9 @@ class CartoDBServiceV2 {
         logger.debug('Checking existing national geo');
         const query = {
             'info.iso': iso.toUpperCase(),
-            'info.simplifyThresh': thresh
+            'info.simplifyThresh': thresh,
+            'info.id1': null,
+            'info.id2': null,
         };
         let existingGeo = yield GeoStoreServiceV2.getGeostoreByInfoProps(query);
         logger.debug('Existed geo', existingGeo);
@@ -163,7 +165,8 @@ class CartoDBServiceV2 {
         const query = {
             'info.iso': iso.toUpperCase(),
             'info.id1': id1,
-            'info.simplifyThresh': thresh
+            'info.id2': null,
+            'info.simplifyThresh': thresh,
         };
 
         logger.debug('Checking existing subnational geo');


### PR DESCRIPTION
Previously the geostore service was incorrectly checking against the Mongo database when a simplfyThresh param was specified. In some cases returning multiple entries and returning only the first.

This adds more strict query params (using iso, id1, id2) so that only the correct entry is returned.

To test, check the following return the correct location:

`v2/admin/BRA?simplify=0.005`
`v2/admin/BRA/23?simplify=0.005`
`v2/admin/USA/10?simplify=0.005`

Note, there seems to be a (separate) testing issue. 