### PR TITLE
Feat/multiple geostores

### DIFF
--- a/app/microservice/register.json
+++ b/app/microservice/register.json
@@ -22,6 +22,16 @@
       ]
     },
     {
+      "url": "/v1/geostore/multiple",
+      "method": "POST",
+      "endpoints": [
+        {
+          "method": "POST",
+          "path": "/api/v1/geostore/multiple"
+        }
+      ]
+    },
+    {
       "url": "/v1/geostore/area",
       "method": "POST",
       "endpoints": [

--- a/app/microservice/register.json
+++ b/app/microservice/register.json
@@ -22,12 +22,12 @@
       ]
     },
     {
-      "url": "/v1/geostore/multiple",
+      "url": "/v1/geostore/find-by-ids",
       "method": "POST",
       "endpoints": [
         {
           "method": "POST",
-          "path": "/api/v1/geostore/multiple"
+          "path": "/api/v1/geostore/find-by-ids"
         }
       ]
     },

--- a/app/src/routes/api/v1/geoStoreRouter.js
+++ b/app/src/routes/api/v1/geoStoreRouter.js
@@ -18,8 +18,6 @@ const router = new Router({
     prefix: '/geostore'
 });
 
-const MAX_GEOSTORES_BY_ID = config.get('constants.max_geostores_by_id');
-
 class GeoStoreRouter {
 
     static* getGeoStoreById() {
@@ -46,26 +44,26 @@ class GeoStoreRouter {
 
     static async getMultipleGeoStores() {
         this.assert(this.request.body.geostores, 400, 'Geostores not found');
-        const geostores = this.request.body.geostores
-        const ids = geostores.map(el => {return el.geostore});
+        const { geostores } = this.request.body;
+        const ids = geostores.map((el) => el.geostore);
 
         logger.debug('Getting geostore by hash %s', ids);
 
-        let geoStores = await GeoStoreService.getMultipleGeostores(ids);
+        const geoStores = await GeoStoreService.getMultipleGeostores(ids);
         if (!geoStores || geoStores.length === 0) {
             this.throw(404, 'No GeoStores found');
             return;
         }
         const foundGeoStores = geoStores.length;
-        logger.debug(`Found ${foundGeoStores} matching geostores. Returning ${MAX_GEOSTORES_BY_ID > foundGeoStores ? foundGeoStores : MAX_GEOSTORES_BY_ID}.`);
-        const slicedGeoStores = geoStores.slice(0, MAX_GEOSTORES_BY_ID)
+        logger.debug(`Found ${foundGeoStores} matching geostores. Returning ${config.get('constants.maxGeostoresFoundById') > foundGeoStores ? foundGeoStores : config.get('constants.maxGeostoresFoundById')}.`);
+        const slicedGeoStores = geoStores.slice(0, config.get('constants.maxGeostoresFoundById'));
         const parsedData = {
             geostores: slicedGeoStores,
-            geostoresFound: geoStores.map(el => el.hash),
+            geostoresFound: geoStores.map((el) => el.hash),
             found: foundGeoStores,
             returned: slicedGeoStores.length
 
-        }
+        };
         this.body = GeoStoreListSerializer.serialize(parsedData);
 
     }

--- a/app/src/routes/api/v1/geoStoreRouter.js
+++ b/app/src/routes/api/v1/geoStoreRouter.js
@@ -233,7 +233,7 @@ class GeoStoreRouter {
 
 router.get('/:hash', GeoStoreRouter.getGeoStoreById);
 router.post('/', GeoStoreValidator.create, GeoStoreRouter.createGeoStore);
-router.post('/multiple', GeoStoreRouter.getMultipleGeoStores);
+router.post('/find-by-ids', GeoStoreRouter.getMultipleGeoStores);
 router.post('/area', GeoStoreValidator.create, GeoStoreRouter.getArea);
 router.get('/admin/:iso', GeoStoreRouter.getNational);
 router.get('/admin/list', GeoStoreRouter.getNationalList);

--- a/app/src/routes/api/v1/geoStoreRouter.js
+++ b/app/src/routes/api/v1/geoStoreRouter.js
@@ -12,12 +12,13 @@ const ProviderNotFound = require('errors/providerNotFound');
 const GeoJSONNotFound = require('errors/geoJSONNotFound');
 const { geojsonToArcGIS } = require('arcgis-to-geojson-utils');
 const { arcgisToGeoJSON } = require('arcgis-to-geojson-utils');
+const config = require('config');
 
 const router = new Router({
     prefix: '/geostore'
 });
 
-const LIMIT = 50;
+const MAX_GEOSTORES_BY_ID = config.get('constants.max_geostores_by_id');
 
 class GeoStoreRouter {
 
@@ -56,8 +57,8 @@ class GeoStoreRouter {
             return;
         }
         const foundGeoStores = geoStores.length;
-        logger.debug(`Found ${foundGeoStores} matching geostores. Returning ${LIMIT > foundGeoStores ? foundGeoStores : LIMIT}.`);
-        const slicedGeoStores = geoStores.slice(0, LIMIT)
+        logger.debug(`Found ${foundGeoStores} matching geostores. Returning ${MAX_GEOSTORES_BY_ID > foundGeoStores ? foundGeoStores : MAX_GEOSTORES_BY_ID}.`);
+        const slicedGeoStores = geoStores.slice(0, MAX_GEOSTORES_BY_ID)
         const parsedData = {
             geostores: slicedGeoStores,
             geostoresFound: geoStores.map(el => el.hash),

--- a/app/src/routes/api/v1/geoStoreRouter.js
+++ b/app/src/routes/api/v1/geoStoreRouter.js
@@ -44,14 +44,14 @@ class GeoStoreRouter {
 
     }
 
-    static* getMultipleGeoStores() {
+    static async getMultipleGeoStores() {
         this.assert(this.request.body.geostores, 400, 'Geostores not found');
         const geostores = this.request.body.geostores
         const ids = geostores.map(el => {return el.geostore});
 
         logger.debug('Getting geostore by hash %s', ids);
 
-        let geoStores = yield GeoStoreService.getMultipleGeostores(ids);
+        let geoStores = await GeoStoreService.getMultipleGeostores(ids);
         if (!geoStores || geoStores.length === 0) {
             this.throw(404, 'No GeoStores found');
             return;

--- a/app/src/serializers/geoStoreListSerializer.js
+++ b/app/src/serializers/geoStoreListSerializer.js
@@ -1,5 +1,5 @@
 
-const logger = require('logger');
+const GeoJSONSerializer = require('serializers/geoJSONSerializer');
 
 
 class GeoStoreListSerializer {
@@ -8,7 +8,7 @@ class GeoStoreListSerializer {
         return {
             data: data.geostores.map((el) => ({
                 geostoreId: el.hash,
-                geojson: el.geojson
+                geostore: GeoJSONSerializer.serialize(el)
             })),
             info: {
                 found: data.found,

--- a/app/src/serializers/geoStoreListSerializer.js
+++ b/app/src/serializers/geoStoreListSerializer.js
@@ -1,0 +1,23 @@
+
+const logger = require('logger');
+
+
+class GeoStoreListSerializer {
+
+    static serialize(data) {
+        return {
+            data: data.geostores.map((el) => ({
+                geostoreId: el.hash,
+                geojson: el.geojson
+            })),
+            info: {
+                found: data.found,
+                foundIds: data.geostoresFound,
+                returned: data.returned
+            }
+        };
+    }
+
+}
+
+module.exports = GeoStoreListSerializer;

--- a/app/src/services/geoStoreService.js
+++ b/app/src/services/geoStoreService.js
@@ -108,6 +108,20 @@ class GeoStoreService {
         return null;
     }
 
+    static* getMultipleGeostores(ids) {
+        logger.debug(`Getting geostores with ids: ${ids}`);
+        const hashes = yield ids.map(id => {
+            return GeoStoreService.getNewHash(id)
+        });
+        const query =  { hash: { $in: hashes } };
+        const geoStores = yield GeoStore.find(query);
+
+        if (geoStores && geoStores.length > 0) {
+            return geoStores;
+        }
+        return null;
+    }
+
     static* getNationalList() {
         logger.debug('Obtaining national list from database');
         const query = {

--- a/app/src/services/geoStoreService.js
+++ b/app/src/services/geoStoreService.js
@@ -108,13 +108,13 @@ class GeoStoreService {
         return null;
     }
 
-    static* getMultipleGeostores(ids) {
+    static async getMultipleGeostores(ids) {
         logger.debug(`Getting geostores with ids: ${ids}`);
-        const hashes = yield ids.map(id => {
+        const hashes = await ids.map(id => {
             return GeoStoreService.getNewHash(id)
         });
         const query =  { hash: { $in: hashes } };
-        const geoStores = yield GeoStore.find(query);
+        const geoStores = await GeoStore.find(query);
 
         if (geoStores && geoStores.length > 0) {
             return geoStores;

--- a/app/src/services/geoStoreService.js
+++ b/app/src/services/geoStoreService.js
@@ -9,6 +9,7 @@ const ProviderNotFound = require('errors/providerNotFound');
 const GeoJSONNotFound = require('errors/geoJSONNotFound');
 const UnknownGeometry = require('errors/unknownGeometry');
 const config = require('config');
+const { promisify } = require('util');
 
 const CARTO_PROVIDER = 'carto';
 
@@ -31,9 +32,11 @@ class GeoStoreService {
 
         if (geojson.type === 'Point' || geojson.type === 'MultiPoint') {
             return 1;
-        } if (geojson.type === 'LineString' || geojson.type === 'MultiLineString') {
+        }
+        if (geojson.type === 'LineString' || geojson.type === 'MultiLineString') {
             return 2;
-        } if (geojson.type === 'Polygon' || geojson.type === 'MultiPolygon') {
+        }
+        if (geojson.type === 'Polygon' || geojson.type === 'MultiPolygon') {
             return 3;
         }
         throw new UnknownGeometry(`Unknown geometry type: ${geojson.type}`);
@@ -96,6 +99,14 @@ class GeoStoreService {
         return idCon.hash;
     }
 
+    static async getNewHashPromise(hash) {
+        const idCon = await IdConnection.findOne({ oldId: hash }).exec();
+        if (!idCon) {
+            return hash;
+        }
+        return idCon.hash;
+    }
+
     static* getGeostoreById(id) {
         logger.debug(`Getting geostore by id ${id}`);
         const hash = yield GeoStoreService.getNewHash(id);
@@ -110,10 +121,8 @@ class GeoStoreService {
 
     static async getMultipleGeostores(ids) {
         logger.debug(`Getting geostores with ids: ${ids}`);
-        const hashes = await ids.map(id => {
-            return GeoStoreService.getNewHash(id)
-        });
-        const query =  { hash: { $in: hashes } };
+        const hashes = await Promise.all(ids.map(GeoStoreService.getNewHashPromise));
+        const query = { hash: { $in: hashes } };
         const geoStores = await GeoStore.find(query);
 
         if (geoStores && geoStores.length > 0) {
@@ -182,18 +191,18 @@ class GeoStoreService {
 
         let props = null;
         const geom_type = geoStore.geojson.type || null;
-        if (geom_type && geom_type === "FeatureCollection") {
-            logger.info('Preserving FeatureCollection properties.')
+        if (geom_type && geom_type === 'FeatureCollection') {
+            logger.info('Preserving FeatureCollection properties.');
             props = geoStore.geojson.features[0].properties || null;
-        } else if(geom_type && geom_type === "Feature"){
-            logger.info('Preserving Feature properties.')
+        } else if (geom_type && geom_type === 'Feature') {
+            logger.info('Preserving Feature properties.');
             props = geoStore.geojson.properties || null;
-        } else{
-            logger.info('Preserving Geometry properties.')
+        } else {
+            logger.info('Preserving Geometry properties.');
             props = geoStore.geojson.properties || null;
         }
         logger.debug('Props', JSON.stringify(props));
-        
+
         if (data && data.info) {
             geoStore.info = data.info;
         }

--- a/app/src/services/geoStoreServiceV2.js
+++ b/app/src/services/geoStoreServiceV2.js
@@ -171,14 +171,14 @@ class GeoStoreServiceV2 {
         }
         let props = null;
         const geom_type = geoStore.geojson.type || null;
-        if (geom_type && geom_type === "FeatureCollection") {
-            logger.info('Preserving FeatureCollection properties.')
+        if (geom_type && geom_type === 'FeatureCollection') {
+            logger.info('Preserving FeatureCollection properties.');
             props = geoStore.geojson.features[0].properties || null;
-        } else if(geom_type && geom_type === "Feature"){
-            logger.info('Preserving Feature properties.')
+        } else if (geom_type && geom_type === 'Feature') {
+            logger.info('Preserving Feature properties.');
             props = geoStore.geojson.properties || null;
-        } else{
-            logger.info('Preserving Geometry properties.')
+        } else {
+            logger.info('Preserving Geometry properties.');
             props = geoStore.geojson.properties || null;
         }
         logger.debug('Props', JSON.stringify(props));

--- a/app/test/e2e/utils/queries-v1.js
+++ b/app/test/e2e/utils/queries-v1.js
@@ -1,4 +1,4 @@
-const createQueryISOName = iso => `SELECT iso, name_0 as name
+const createQueryISOName = (iso) => `SELECT iso, name_0 as name
         FROM gadm2_countries_simple
         WHERE iso in ${iso}`;
 
@@ -17,7 +17,7 @@ const createQueryUSE = (cartodbId, useTable) => `SELECT ST_AsGeoJSON(st_makevali
         FROM ${useTable}
         WHERE cartodb_id = ${cartodbId}`;
 
-const createQueryWDPA = wdpaId => `SELECT ST_AsGeoJSON(st_makevalid(p.the_geom)) AS geojson, (ST_Area(geography(the_geom))/10000) as area_ha
+const createQueryWDPA = (wdpaId) => `SELECT ST_AsGeoJSON(st_makevalid(p.the_geom)) AS geojson, (ST_Area(geography(the_geom))/10000) as area_ha
         FROM (
           SELECT CASE
           WHEN marine::numeric = 2 THEN NULL
@@ -29,7 +29,7 @@ const createQueryWDPA = wdpaId => `SELECT ST_AsGeoJSON(st_makevalid(p.the_geom))
           WHERE wdpaid=${wdpaId}
         ) p`;
 
-const createQueryGeometry = data => `SELECT ST_AsGeoJson(ST_CollectionExtract(st_MakeValid(ST_GeomFromGeoJSON('${data}')),3)) as geojson`;
+const createQueryGeometry = (data) => `SELECT ST_AsGeoJson(ST_CollectionExtract(st_MakeValid(ST_GeomFromGeoJSON('${data}')),3)) as geojson`;
 
 module.exports = {
     createQueryID1,

--- a/app/test/e2e/utils/queries-v2.js
+++ b/app/test/e2e/utils/queries-v2.js
@@ -1,4 +1,4 @@
-const createQueryWDPA = wdpaId => `SELECT ST_AsGeoJSON(ST_MAKEVALID(p.the_geom)) AS geojson, (ST_Area(geography(the_geom))/10000) as area_ha
+const createQueryWDPA = (wdpaId) => `SELECT ST_AsGeoJSON(ST_MAKEVALID(p.the_geom)) AS geojson, (ST_Area(geography(the_geom))/10000) as area_ha
         FROM (
           SELECT CASE
           WHEN marine::numeric = 2 THEN NULL

--- a/app/test/e2e/v1/geostore-create.spec.js
+++ b/app/test/e2e/v1/geostore-create.spec.js
@@ -59,14 +59,14 @@ describe('Geostore v1 tests - Create geostores', () => {
             .send({
                 geojson: {
                     type: 'FeatureCollection',
-                    "properties": {
-                        "some": "property"
-                      },
+                    properties: {
+                        some: 'property'
+                    },
                     features: [{
                         type: 'Feature',
-                        "properties": {
-                        "some": "property"
-                      },
+                        properties: {
+                            some: 'property'
+                        },
                         geometry: {
                             type: 'MultiPoint',
                             coordinates: [

--- a/app/test/e2e/v1/geostore-get-multiple.spec.js
+++ b/app/test/e2e/v1/geostore-get-multiple.spec.js
@@ -5,7 +5,7 @@ const config = require('config');
 const GeoStore = require('models/geoStore');
 const logger = require('logger');
 
-const { createGeostore } = require('../utils/utils');
+const { createGeostore, getUUID } = require('../utils/utils');
 const { getTestServer } = require('../utils/test-server');
 
 const should = chai.should();
@@ -54,6 +54,33 @@ describe('Geostore v1 tests - Get multiple geostorea', () => {
         response.body.should.have.property('info').and.be.an('object');
         response.body.info.should.have.property('found').and.equal(3);
         response.body.info.should.have.property('returned').and.equal(2);
+        response.body.info.should.have.property('foundIds').and.be.an('array');
+        
+    });
+
+    it('Get geostores some geostores that dont exist return a 200', async () => {
+        const createdGeostore1 = await createGeostore({areaHa:205.64210228373287, bbox: [], info: { iso: 'MCO', id1: null, id2: null, gadm: '2.8'} });
+        const randomGeostoreID1 = getUUID();
+        const randomGeostoreID2 = getUUID();
+
+        const response = await requester.post(`/api/v1/geostore/find-by-ids`)
+            .send({
+                geostores: [
+                    {
+                        geostore: createdGeostore1.hash
+                    },{
+                        geostore: randomGeostoreID1
+                    },{
+                        geostore: randomGeostoreID2
+                    }
+                ]
+            });
+
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array');
+        response.body.should.have.property('info').and.be.an('object');
+        response.body.info.should.have.property('found').and.equal(1);
+        response.body.info.should.have.property('returned').and.equal(1);
         response.body.info.should.have.property('foundIds').and.be.an('array');
         
     });

--- a/app/test/e2e/v1/geostore-get-multiple.spec.js
+++ b/app/test/e2e/v1/geostore-get-multiple.spec.js
@@ -1,0 +1,69 @@
+/* eslint-disable no-unused-vars,no-undef */
+const nock = require('nock');
+const chai = require('chai');
+const config = require('config');
+const GeoStore = require('models/geoStore');
+const logger = require('logger');
+
+const { createGeostore } = require('../utils/utils');
+const { getTestServer } = require('../utils/test-server');
+
+const should = chai.should();
+
+let requester;
+nock.disableNetConnect();
+nock.enableNetConnect(process.env.HOST_IP);
+
+describe('Geostore v1 tests - Get multiple geostorea', () => {
+
+    before(async () => {
+        if (process.env.NODE_ENV !== 'test') {
+            throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
+        }
+        if (config.get('cartoDB.user') === null) {
+            throw Error(`Carto user not set - please specify a CARTODB_USER env var with it.`);
+        }
+
+        requester = await getTestServer();
+
+        GeoStore.remove({}).exec();
+
+        nock.cleanAll();
+    });
+
+    it('Get geostores that have been saved to the local database should return a 200', async () => {
+        const createdGeostore1 = await createGeostore({areaHa:205.64210228373287, bbox: [], info: { iso: 'MCO', id1: null, id2: null, gadm: '2.8'} });
+        const createdGeostore2 = await createGeostore({areaHa:206.64210228373287, bbox: [], info: { iso: 'BRA', id1: null, id2: null, gadm: '2.8'} });
+        const createdGeostore3 = await createGeostore({areaHa:207.64210228373287, bbox: [], info: { iso: 'ESP', id1: null, id2: null, gadm: '2.8'} });
+
+        const response = await requester.post(`/api/v1/geostore/find-by-ids`)
+            .send({
+                geostores: [
+                    {
+                        geostore: createdGeostore1.hash
+                    },{
+                        geostore: createdGeostore2.hash
+                    },{
+                        geostore: createdGeostore3.hash
+                    }
+                ]
+            });
+
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array');
+        response.body.should.have.property('info').and.be.an('object');
+        response.body.info.should.have.property('found').and.equal(3);
+        response.body.info.should.have.property('foundIds').and.be.an('array');
+        
+    });
+
+    afterEach(() => {
+        if (!nock.isDone()) {
+            throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
+        }
+    });
+
+    after(() => {
+        GeoStore.remove({}).exec();
+    });
+});

--- a/app/test/e2e/v1/geostore-get-multiple.spec.js
+++ b/app/test/e2e/v1/geostore-get-multiple.spec.js
@@ -32,18 +32,36 @@ describe('Geostore v1 tests - Get multiple geostorea', () => {
     });
 
     it('Get geostores that have been saved to the local database should max of 2 geosstores, return a 200', async () => {
-        const createdGeostore1 = await createGeostore({areaHa:205.64210228373287, bbox: [], info: { iso: 'MCO', id1: null, id2: null, gadm: '2.8'} });
-        const createdGeostore2 = await createGeostore({areaHa:206.64210228373287, bbox: [], info: { iso: 'BRA', id1: null, id2: null, gadm: '2.8'} });
-        const createdGeostore3 = await createGeostore({areaHa:207.64210228373287, bbox: [], info: { iso: 'ESP', id1: null, id2: null, gadm: '2.8'} });
+        const createdGeostore1 = await createGeostore({
+            areaHa: 205.64210228373287,
+            bbox: [],
+            info: {
+                iso: 'MCO', id1: null, id2: null, gadm: '2.8'
+            }
+        });
+        const createdGeostore2 = await createGeostore({
+            areaHa: 206.64210228373287,
+            bbox: [],
+            info: {
+                iso: 'BRA', id1: null, id2: null, gadm: '2.8'
+            }
+        });
+        const createdGeostore3 = await createGeostore({
+            areaHa: 207.64210228373287,
+            bbox: [],
+            info: {
+                iso: 'ESP', id1: null, id2: null, gadm: '2.8'
+            }
+        });
 
         const response = await requester.post(`/api/v1/geostore/find-by-ids`)
             .send({
                 geostores: [
                     {
                         geostore: createdGeostore1.hash
-                    },{
+                    }, {
                         geostore: createdGeostore2.hash
-                    },{
+                    }, {
                         geostore: createdGeostore3.hash
                     }
                 ]
@@ -55,11 +73,17 @@ describe('Geostore v1 tests - Get multiple geostorea', () => {
         response.body.info.should.have.property('found').and.equal(3);
         response.body.info.should.have.property('returned').and.equal(2);
         response.body.info.should.have.property('foundIds').and.be.an('array');
-        
+
     });
 
     it('Get geostores some geostores that dont exist return a 200', async () => {
-        const createdGeostore1 = await createGeostore({areaHa:205.64210228373287, bbox: [], info: { iso: 'MCO', id1: null, id2: null, gadm: '2.8'} });
+        const createdGeostore1 = await createGeostore({
+            areaHa: 205.64210228373287,
+            bbox: [],
+            info: {
+                iso: 'MCO', id1: null, id2: null, gadm: '2.8'
+            }
+        });
         const randomGeostoreID1 = getUUID();
         const randomGeostoreID2 = getUUID();
 
@@ -68,9 +92,9 @@ describe('Geostore v1 tests - Get multiple geostorea', () => {
                 geostores: [
                     {
                         geostore: createdGeostore1.hash
-                    },{
+                    }, {
                         geostore: randomGeostoreID1
-                    },{
+                    }, {
                         geostore: randomGeostoreID2
                     }
                 ]
@@ -82,7 +106,7 @@ describe('Geostore v1 tests - Get multiple geostorea', () => {
         response.body.info.should.have.property('found').and.equal(1);
         response.body.info.should.have.property('returned').and.equal(1);
         response.body.info.should.have.property('foundIds').and.be.an('array');
-        
+
     });
 
     afterEach(() => {

--- a/app/test/e2e/v1/geostore-get-multiple.spec.js
+++ b/app/test/e2e/v1/geostore-get-multiple.spec.js
@@ -31,7 +31,7 @@ describe('Geostore v1 tests - Get multiple geostorea', () => {
         nock.cleanAll();
     });
 
-    it('Get geostores that have been saved to the local database should max of 2 geosstores, return a 200', async () => {
+    it('Get geostores that have been saved to the local database should max of 2 geostores, return a 200', async () => {
         const createdGeostore1 = await createGeostore({
             areaHa: 205.64210228373287,
             bbox: [],

--- a/app/test/e2e/v1/geostore-get-multiple.spec.js
+++ b/app/test/e2e/v1/geostore-get-multiple.spec.js
@@ -31,7 +31,7 @@ describe('Geostore v1 tests - Get multiple geostorea', () => {
         nock.cleanAll();
     });
 
-    it('Get geostores that have been saved to the local database should return a 200', async () => {
+    it('Get geostores that have been saved to the local database should max of 2 geosstores, return a 200', async () => {
         const createdGeostore1 = await createGeostore({areaHa:205.64210228373287, bbox: [], info: { iso: 'MCO', id1: null, id2: null, gadm: '2.8'} });
         const createdGeostore2 = await createGeostore({areaHa:206.64210228373287, bbox: [], info: { iso: 'BRA', id1: null, id2: null, gadm: '2.8'} });
         const createdGeostore3 = await createGeostore({areaHa:207.64210228373287, bbox: [], info: { iso: 'ESP', id1: null, id2: null, gadm: '2.8'} });
@@ -53,6 +53,7 @@ describe('Geostore v1 tests - Get multiple geostorea', () => {
         response.body.should.have.property('data').and.be.an('array');
         response.body.should.have.property('info').and.be.an('object');
         response.body.info.should.have.property('found').and.equal(3);
+        response.body.info.should.have.property('returned').and.equal(2);
         response.body.info.should.have.property('foundIds').and.be.an('array');
         
     });

--- a/app/test/e2e/v1/geostore-get-national.spec.js
+++ b/app/test/e2e/v1/geostore-get-national.spec.js
@@ -105,7 +105,13 @@ describe('Geostore v1 tests - Get geostore - National level', () => {
     });
 
     it('Get country that has been saved to the local database should return a 200', async () => {
-        const createdNational = await createGeostore({areaHa:205.64210228373287, bbox: [], info: { iso: 'MCO', id1: null, id2: null, gadm: '2.8'} });
+        const createdNational = await createGeostore({
+            areaHa: 205.64210228373287,
+            bbox: [],
+            info: {
+                iso: 'MCO', id1: null, id2: null, gadm: '2.8'
+            }
+        });
         const response = await requester.get(`/api/v1/geostore/admin/MCO`).send();
 
         response.status.should.equal(200);
@@ -122,7 +128,7 @@ describe('Geostore v1 tests - Get geostore - National level', () => {
 
         response.body.data.attributes.info.should.have.property('gadm').and.equal('2.8');
         response.body.data.attributes.info.should.have.property('iso').and.equal('MCO');
-        
+
     });
 
     afterEach(() => {

--- a/app/test/e2e/v1/geostore-get-regional.spec.js
+++ b/app/test/e2e/v1/geostore-get-regional.spec.js
@@ -57,7 +57,11 @@ describe('Geostore v1 tests - Get geostore sub sub national', () => {
         const testID = 123;
         const testID2 = 123;
         const testISO = 'TEST123';
-        const createdSubnational = await createGeostore({ info: { iso: testISO, id1: testID, id2: testID2, gadm: '2.8' } });
+        const createdSubnational = await createGeostore({
+            info: {
+                iso: testISO, id1: testID, id2: testID2, gadm: '2.8'
+            }
+        });
 
         const response = await subnational.get(`/${testISO}/${testID}/${testID2}`);
 

--- a/app/test/e2e/v1/geostore-get-subreional.spec.js
+++ b/app/test/e2e/v1/geostore-get-subreional.spec.js
@@ -54,7 +54,11 @@ describe('Geostore v1 tests - Get geostore subnational by id', () => {
     it('Getting subnational by id should return directly from db when it was created (happy case)', async () => {
         const testID = 123;
         const testISO = 'TEST123';
-        const createdSubnational = await createGeostore({ info: { iso: testISO, id1: testID , id2: null, gadm: '2.8'} });
+        const createdSubnational = await createGeostore({
+            info: {
+                iso: testISO, id1: testID, id2: null, gadm: '2.8'
+            }
+        });
 
         const response = await subnational.get(`/${testISO}/${testID}`);
 

--- a/app/test/e2e/v2/geostore-create.spec.js
+++ b/app/test/e2e/v2/geostore-create.spec.js
@@ -64,9 +64,9 @@ describe('Geostore v2 tests - Create geostores', () => {
                     type: 'FeatureCollection',
                     features: [{
                         type: 'Feature',
-                        "properties": {
-                        "some": "property"
-                      },
+                        properties: {
+                            some: 'property'
+                        },
                         geometry: {
                             type: 'MultiPoint',
                             coordinates: [

--- a/app/test/unit/converters/geoJSONConverter.test.js
+++ b/app/test/unit/converters/geoJSONConverter.test.js
@@ -57,7 +57,7 @@ describe('Error serializer test', () => {
         feature.should.have.property('geometry');
         feature.geometry.should.be.an('object');
 
-        const geometry = feature.geometry;
+        const { geometry } = feature;
         geometry.should.have.property('type');
         geometry.type.should.be.equal(featureCollectionExample.features[0].geometry.type);
         geometry.should.have.a.property('coordinates');
@@ -79,7 +79,7 @@ describe('Error serializer test', () => {
         feature.should.have.property('geometry');
         feature.geometry.should.be.an('object');
 
-        const geometry = feature.geometry;
+        const { geometry } = feature;
         geometry.should.have.property('type');
         geometry.type.should.be.equal(featureCollectionExample.features[0].geometry.type);
         geometry.should.have.a.property('coordinates');
@@ -101,7 +101,7 @@ describe('Error serializer test', () => {
         feature.should.have.property('geometry');
         feature.geometry.should.be.an('object');
 
-        const geometry = feature.geometry;
+        const { geometry } = feature;
         geometry.should.have.property('type');
         geometry.type.should.be.equal(featureCollectionExample.features[0].geometry.type);
         geometry.should.have.a.property('coordinates');

--- a/app/test/unit/serializers/geoJSONSerializer.test.js
+++ b/app/test/unit/serializers/geoJSONSerializer.test.js
@@ -61,7 +61,7 @@ describe('GeoJSON serializer test', () => {
         const response = GeoJSONSerializer.serialize(single);
         response.should.not.be.an('array');
         response.should.have.property('data');
-        const data = response.data;
+        const { data } = response;
         data.should.have.property('type');
         data.should.have.property('attributes');
         data.should.have.property('id');
@@ -77,7 +77,7 @@ describe('GeoJSON serializer test', () => {
         feature.type.should.be.equal(single.geojson.features[0].type);
         feature.should.have.property('geometry');
         feature.geometry.should.be.an('object');
-        const geometry = feature.geometry;
+        const { geometry } = feature;
         geometry.should.have.property('type');
         geometry.type.should.be.equal(single.geojson.features[0].geometry.type);
         geometry.should.have.a.property('coordinates');
@@ -90,7 +90,7 @@ describe('GeoJSON serializer test', () => {
         const response = GeoJSONSerializer.serialize(severalFeatures);
         response.should.not.be.an('array');
         response.should.have.property('data');
-        const data = response.data;
+        const { data } = response;
         data.should.have.property('type');
         data.should.have.property('attributes');
         data.should.have.property('id');
@@ -106,7 +106,7 @@ describe('GeoJSON serializer test', () => {
         feature.type.should.be.equal(severalFeatures.geojson.features[0].type);
         feature.should.have.property('geometry');
         feature.geometry.should.be.an('object');
-        const geometry = feature.geometry;
+        const { geometry } = feature;
         geometry.should.have.property('type');
         geometry.type.should.be.equal(severalFeatures.geojson.features[0].geometry.type);
         geometry.should.have.a.property('coordinates');

--- a/config/default.json
+++ b/config/default.json
@@ -21,5 +21,8 @@
   },
   "cartoDB": {
     "user": null
+  },
+  "constants": {
+    "max_geostores_by_id": 50
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -23,6 +23,6 @@
     "user": null
   },
   "constants": {
-    "max_geostores_by_id": 50
+    "maxGeostoresFoundById": 50
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -11,6 +11,6 @@
     "port": 27017
   },
   "constants": {
-    "max_geostores_by_id": 2
+    "maxGeostoresFoundById": 2
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -9,5 +9,8 @@
     "database": "gfw_geostore_db_test",
     "host": "mymachine",
     "port": 27017
+  },
+  "constants": {
+    "max_geostores_by_id": 2
   }
 }


### PR DESCRIPTION
# Summary

Adds `POST` endpoint to `/v1/geostore/multiple`which allows users to fetch multiple geostores by id.  Currently returns an array of found geostore objects in `data` key, as well as metadata on what was found in the `info` key.

Currently implements a hard upper limit on the number of geojsons returned, but does return an array of all ids found (even if not all are returned) in `data.info.foundIds`.

Expected Payload:

```
{
    "geostores": [
	{
	    "geostore": "3e0cc35138854a791570103e0c8aaf48",
	     ...
	},{
	    "geostore": "c9a001bd485484919ac8b8d8402770e6",
	    ...
	}
	
	]
}
```

200 Response:

```
{
    "data": [
        {
            "geostoreId": "3e0cc35138854a791570103e0c8aaf48",
            "geostore": {
                "geojson": {...},
                "crs": {},
                "type": "FeatureCollection"
            }
        },
        {
            "geostoreId": "c9a001bd485484919ac8b8d8402770e6",
            "geostore": {...},
                "crs": {},
                "type": "FeatureCollection"
            }
        }
    ],
    "info": {
        "found": 2,
        "foundIds": [
            "3e0cc35138854a791570103e0c8aaf48",
            "c9a001bd485484919ac8b8d8402770e6",
        ...
        ],
        "returned": 2
    }
}
```

## Open Questions

- What should the limit size be? Requires testing.

## To Do

- Add tests
- Update Docs