### PR TITLE
Feat/multiple geostore v2

### DIFF
--- a/app/microservice/register.json
+++ b/app/microservice/register.json
@@ -172,6 +172,16 @@
       ]
     },
     {
+      "url": "/v2/geostore/find-by-ids",
+      "method": "POST",
+      "endpoints": [
+        {
+          "method": "POST",
+          "path": "/api/v2/geostore/find-by-ids"
+        }
+      ]
+    },
+    {
       "url": "/v2/geostore/area",
       "method": "POST",
       "endpoints": [

--- a/app/microservice/register.json
+++ b/app/microservice/register.json
@@ -22,6 +22,16 @@
       ]
     },
     {
+      "url": "/v1/geostore/find-by-ids",
+      "method": "POST",
+      "endpoints": [
+        {
+          "method": "POST",
+          "path": "/api/v1/geostore/find-by-ids"
+        }
+      ]
+    },
+    {
       "url": "/v1/geostore/area",
       "method": "POST",
       "endpoints": [

--- a/app/src/converters/geoJSONConverter.js
+++ b/app/src/converters/geoJSONConverter.js
@@ -1,14 +1,14 @@
 
 const logger = require('logger');
 
-module.exports.makeFeatureCollection = function (data) {
+module.exports.makeFeatureCollection = function (data, props) {
     if (data.type === 'FeatureCollection') {
         logger.debug('Is a FeatureCollection');
-        data.features.properties = null;
+        data.features.properties = props;
         return data;
     } if (data.type === 'Feature') {
         logger.debug('Is a feature');
-        data.properties = null;
+        data.properties = props;
         return {
             type: 'FeatureCollection',
             features: [data],
@@ -25,7 +25,7 @@ module.exports.makeFeatureCollection = function (data) {
         type: 'FeatureCollection',
         features: [{
             type: 'Feature',
-            properties: null,
+            properties: props,
             geometry: data
         }],
         /*  crs: {

--- a/app/src/routes/api/v1/geoStoreRouter.js
+++ b/app/src/routes/api/v1/geoStoreRouter.js
@@ -45,7 +45,11 @@ class GeoStoreRouter {
     static async getMultipleGeoStores() {
         this.assert(this.request.body.geostores, 400, 'Geostores not found');
         const { geostores } = this.request.body;
-        const ids = geostores.map((el) => el.geostore);
+        if (!geostores || geostores.length === 0) {
+            this.throw(404, 'No GeoStores in payload');
+            return;
+        }
+        const ids = geostores.map(el => el.trim());
 
         logger.debug('Getting geostore by hash %s', ids);
 

--- a/app/src/routes/api/v1/geoStoreRouter.js
+++ b/app/src/routes/api/v1/geoStoreRouter.js
@@ -72,7 +72,7 @@ class GeoStoreRouter {
     }
 
     static* getArea() {
-        logger.info('Retreiving Polygon Area');
+        logger.info('Retrieving Polygon Area');
         try {
             const data = {
                 provider: this.request.body.provider,

--- a/app/src/routes/api/v2/geoStoreRouter.js
+++ b/app/src/routes/api/v2/geoStoreRouter.js
@@ -70,7 +70,7 @@ class GeoStoreRouterV2 {
     }
 
     static* getArea() {
-        logger.info('Retreiving Polygon Area');
+        logger.info('Retrieving Polygon Area');
         try {
             const data = {
                 provider: this.request.body.provider,

--- a/app/src/serializers/geoStoreListSerializer.js
+++ b/app/src/serializers/geoStoreListSerializer.js
@@ -1,0 +1,23 @@
+
+const GeoJSONSerializer = require('serializers/geoJSONSerializer');
+
+
+class GeoStoreListSerializer {
+
+    static serialize(data) {
+        return {
+            data: data.geostores.map((el) => ({
+                geostoreId: el.hash,
+                geostore: GeoJSONSerializer.serialize(el)
+            })),
+            info: {
+                found: data.found,
+                foundIds: data.geostoresFound,
+                returned: data.returned
+            }
+        };
+    }
+
+}
+
+module.exports = GeoStoreListSerializer;

--- a/app/src/services/cartoDBService.js
+++ b/app/src/services/cartoDBService.js
@@ -89,6 +89,7 @@ class CartoDBService {
             const geoData = {
                 info: {
                     iso: iso.toUpperCase(),
+                    id1: null,
                     gadm: '2.8'
                 }
             };

--- a/app/src/services/cartoDBService.js
+++ b/app/src/services/cartoDBService.js
@@ -71,8 +71,7 @@ class CartoDBService {
     * getNational(iso) {
         logger.debug('Obtaining national of iso %s', iso);
         const query = {
-            'info.iso': iso.toUpperCase(),
-            'info.id1': null
+            'info.iso': iso.toUpperCase()
         };
         logger.debug('Checking existing national geo');
         let existingGeo = yield GeoStoreService.getGeostoreByInfoProps(query);

--- a/app/src/services/cartoDBService.js
+++ b/app/src/services/cartoDBService.js
@@ -71,7 +71,9 @@ class CartoDBService {
     * getNational(iso) {
         logger.debug('Obtaining national of iso %s', iso);
         const query = {
-            'info.iso': iso.toUpperCase()
+            'info.iso': iso.toUpperCase(),
+            'info.id1': null,
+            'info.id2': null
         };
         logger.debug('Checking existing national geo');
         let existingGeo = yield GeoStoreService.getGeostoreByInfoProps(query);

--- a/app/src/services/cartoDBService.js
+++ b/app/src/services/cartoDBService.js
@@ -90,6 +90,7 @@ class CartoDBService {
                 info: {
                     iso: iso.toUpperCase(),
                     id1: null,
+                    id2: null,
                     gadm: '2.8'
                 }
             };
@@ -129,7 +130,8 @@ class CartoDBService {
         logger.debug('Obtaining subnational of iso %s and id1', iso, id1);
         const params = {
             iso: iso.toUpperCase(),
-            id1: parseInt(id1, 10)
+            id1: parseInt(id1, 10),
+            id2: null
         };
 
         logger.debug('Checking existing subnational geo');

--- a/app/src/services/cartoDBService.js
+++ b/app/src/services/cartoDBService.js
@@ -70,13 +70,14 @@ class CartoDBService {
 
     * getNational(iso) {
         logger.debug('Obtaining national of iso %s', iso);
-        const query = {
-            'info.iso': iso.toUpperCase(),
-            'info.id1': null,
-            'info.id2': null
+        const params = {
+            iso: iso.toUpperCase(),
+            id1: null,
+            id2: null,
+            gadm: '2.8'
         };
         logger.debug('Checking existing national geo');
-        let existingGeo = yield GeoStoreService.getGeostoreByInfoProps(query);
+        let existingGeo = yield GeoStoreService.getGeostoreByInfo(params);
         logger.debug('Existed geo', existingGeo);
         if (existingGeo) {
             logger.debug('Return national geojson stored');
@@ -89,12 +90,7 @@ class CartoDBService {
             const result = data.rows[0];
             logger.debug('Saving national geostore');
             const geoData = {
-                info: {
-                    iso: iso.toUpperCase(),
-                    id1: null,
-                    id2: null,
-                    gadm: '2.8'
-                }
+                info: params
             };
             geoData.info.name = result.name;
             existingGeo = yield GeoStoreService.saveGeostore(JSON.parse(result.geojson), geoData);
@@ -133,7 +129,8 @@ class CartoDBService {
         const params = {
             iso: iso.toUpperCase(),
             id1: parseInt(id1, 10),
-            id2: null
+            id2: null,
+            gadm: '2.8'
         };
 
         logger.debug('Checking existing subnational geo');
@@ -151,8 +148,7 @@ class CartoDBService {
             const result = data.rows[0];
             logger.debug('Saving national geostore');
             const geoData = {
-                info: params,
-                gadm: '2.8'
+                info: params
             };
             existingGeo = yield GeoStoreService.saveGeostore(JSON.parse(result.geojson), geoData);
             return existingGeo;
@@ -165,7 +161,8 @@ class CartoDBService {
         const params = {
             iso: iso.toUpperCase(),
             id1: parseInt(id1, 10),
-            id2: parseInt(id2, 10)
+            id2: parseInt(id2, 10),
+            gadm: '2.8'
         };
 
         logger.debug('Checking existing admin2 geostore');
@@ -183,8 +180,7 @@ class CartoDBService {
             const result = data.rows[0];
             logger.debug('Saving admin2 geostore');
             const geoData = {
-                info: params,
-                gadm: '2.8'
+                info: params
             };
             existingGeo = yield GeoStoreService.saveGeostore(JSON.parse(result.geojson), geoData);
             return existingGeo;

--- a/app/src/services/cartoDBServiceV2.js
+++ b/app/src/services/cartoDBServiceV2.js
@@ -99,7 +99,9 @@ class CartoDBServiceV2 {
         logger.debug('Checking existing national geo');
         const query = {
             'info.iso': iso.toUpperCase(),
-            'info.simplifyThresh': thresh
+            'info.simplifyThresh': thresh,
+            'info.id1': null,
+            'info.id2': null,
         };
         let existingGeo = yield GeoStoreServiceV2.getGeostoreByInfoProps(query);
         logger.debug('Existed geo', existingGeo);
@@ -163,7 +165,8 @@ class CartoDBServiceV2 {
         const query = {
             'info.iso': iso.toUpperCase(),
             'info.id1': id1,
-            'info.simplifyThresh': thresh
+            'info.id2': null,
+            'info.simplifyThresh': thresh,
         };
 
         logger.debug('Checking existing subnational geo');

--- a/app/src/services/geoStoreService.js
+++ b/app/src/services/geoStoreService.js
@@ -165,6 +165,21 @@ class GeoStoreService {
                 filter: data.provider.filter
             };
         }
+
+        let props = null;
+        const geom_type = geoStore.geojson.type || null;
+        if (geom_type && geom_type === "FeatureCollection") {
+            logger.info('Preserving FeatureCollection properties.')
+            props = geoStore.geojson.features[0].properties || null;
+        } else if(geom_type && geom_type === "Feature"){
+            logger.info('Preserving Feature properties.')
+            props = geoStore.geojson.properties || null;
+        } else{
+            logger.info('Preserving Geometry properties.')
+            props = geoStore.geojson.properties || null;
+        }
+        logger.debug('Props', JSON.stringify(props));
+        
         if (data && data.info) {
             geoStore.info = data.info;
         }
@@ -178,7 +193,7 @@ class GeoStoreService {
 
         logger.debug('Repaired geometry', JSON.stringify(geoStore.geojson));
         logger.debug('Make Feature Collection');
-        geoStore.geojson = GeoJSONConverter.makeFeatureCollection(geoStore.geojson);
+        geoStore.geojson = GeoJSONConverter.makeFeatureCollection(geoStore.geojson, props);
         logger.debug('Result', JSON.stringify(geoStore.geojson));
         logger.debug('Creating hash from geojson md5');
         geoStore.hash = md5(JSON.stringify(geoStore.geojson));

--- a/app/src/services/geoStoreService.js
+++ b/app/src/services/geoStoreService.js
@@ -9,6 +9,7 @@ const ProviderNotFound = require('errors/providerNotFound');
 const GeoJSONNotFound = require('errors/geoJSONNotFound');
 const UnknownGeometry = require('errors/unknownGeometry');
 const config = require('config');
+const { promisify } = require('util');
 
 const CARTO_PROVIDER = 'carto';
 
@@ -31,9 +32,11 @@ class GeoStoreService {
 
         if (geojson.type === 'Point' || geojson.type === 'MultiPoint') {
             return 1;
-        } if (geojson.type === 'LineString' || geojson.type === 'MultiLineString') {
+        }
+        if (geojson.type === 'LineString' || geojson.type === 'MultiLineString') {
             return 2;
-        } if (geojson.type === 'Polygon' || geojson.type === 'MultiPolygon') {
+        }
+        if (geojson.type === 'Polygon' || geojson.type === 'MultiPolygon') {
             return 3;
         }
         throw new UnknownGeometry(`Unknown geometry type: ${geojson.type}`);
@@ -96,6 +99,14 @@ class GeoStoreService {
         return idCon.hash;
     }
 
+    static async getNewHashPromise(hash) {
+        const idCon = await IdConnection.findOne({ oldId: hash }).exec();
+        if (!idCon) {
+            return hash;
+        }
+        return idCon.hash;
+    }
+
     static* getGeostoreById(id) {
         logger.debug(`Getting geostore by id ${id}`);
         const hash = yield GeoStoreService.getNewHash(id);
@@ -104,6 +115,18 @@ class GeoStoreService {
         if (geoStore) {
             logger.debug('geostore', JSON.stringify(geoStore.geojson));
             return geoStore;
+        }
+        return null;
+    }
+
+    static async getMultipleGeostores(ids) {
+        logger.debug(`Getting geostores with ids: ${ids}`);
+        const hashes = await Promise.all(ids.map(GeoStoreService.getNewHashPromise));
+        const query = { hash: { $in: hashes } };
+        const geoStores = await GeoStore.find(query);
+
+        if (geoStores && geoStores.length > 0) {
+            return geoStores;
         }
         return null;
     }
@@ -168,18 +191,18 @@ class GeoStoreService {
 
         let props = null;
         const geom_type = geoStore.geojson.type || null;
-        if (geom_type && geom_type === "FeatureCollection") {
-            logger.info('Preserving FeatureCollection properties.')
+        if (geom_type && geom_type === 'FeatureCollection') {
+            logger.info('Preserving FeatureCollection properties.');
             props = geoStore.geojson.features[0].properties || null;
-        } else if(geom_type && geom_type === "Feature"){
-            logger.info('Preserving Feature properties.')
+        } else if (geom_type && geom_type === 'Feature') {
+            logger.info('Preserving Feature properties.');
             props = geoStore.geojson.properties || null;
-        } else{
-            logger.info('Preserving Geometry properties.')
+        } else {
+            logger.info('Preserving Geometry properties.');
             props = geoStore.geojson.properties || null;
         }
         logger.debug('Props', JSON.stringify(props));
-        
+
         if (data && data.info) {
             geoStore.info = data.info;
         }

--- a/app/src/services/geoStoreServiceV2.js
+++ b/app/src/services/geoStoreServiceV2.js
@@ -171,14 +171,14 @@ class GeoStoreServiceV2 {
         }
         let props = null;
         const geom_type = geoStore.geojson.type || null;
-        if (geom_type && geom_type === "FeatureCollection") {
-            logger.info('Preserving FeatureCollection properties.')
+        if (geom_type && geom_type === 'FeatureCollection') {
+            logger.info('Preserving FeatureCollection properties.');
             props = geoStore.geojson.features[0].properties || null;
-        } else if(geom_type && geom_type === "Feature"){
-            logger.info('Preserving Feature properties.')
+        } else if (geom_type && geom_type === 'Feature') {
+            logger.info('Preserving Feature properties.');
             props = geoStore.geojson.properties || null;
-        } else{
-            logger.info('Preserving Geometry properties.')
+        } else {
+            logger.info('Preserving Geometry properties.');
             props = geoStore.geojson.properties || null;
         }
         logger.debug('Props', JSON.stringify(props));

--- a/app/src/services/geoStoreServiceV2.js
+++ b/app/src/services/geoStoreServiceV2.js
@@ -169,6 +169,19 @@ class GeoStoreServiceV2 {
                 filter: data.provider.filter
             };
         }
+        let props = null;
+        const geom_type = geoStore.geojson.type || null;
+        if (geom_type && geom_type === "FeatureCollection") {
+            logger.info('Preserving FeatureCollection properties.')
+            props = geoStore.geojson.features[0].properties || null;
+        } else if(geom_type && geom_type === "Feature"){
+            logger.info('Preserving Feature properties.')
+            props = geoStore.geojson.properties || null;
+        } else{
+            logger.info('Preserving Geometry properties.')
+            props = geoStore.geojson.properties || null;
+        }
+        logger.debug('Props', JSON.stringify(props));
         if (data && data.info) {
             geoStore.info = data.info;
         }
@@ -194,7 +207,7 @@ class GeoStoreServiceV2 {
             logger.debug('Repaired geometry', JSON.stringify(geoStore.geojson));
         }
         logger.debug('Make Feature Collection');
-        geoStore.geojson = GeoJSONConverter.makeFeatureCollection(geoStore.geojson);
+        geoStore.geojson = GeoJSONConverter.makeFeatureCollection(geoStore.geojson, props);
         if (process.env.NODE_ENV !== 'test' || geoStore.geojson.length < 2000) {
             logger.debug('Result', JSON.stringify(geoStore.geojson));
         }

--- a/app/test/e2e/utils/queries-v1.js
+++ b/app/test/e2e/utils/queries-v1.js
@@ -1,4 +1,4 @@
-const createQueryISOName = iso => `SELECT iso, name_0 as name
+const createQueryISOName = (iso) => `SELECT iso, name_0 as name
         FROM gadm2_countries_simple
         WHERE iso in ${iso}`;
 
@@ -17,7 +17,7 @@ const createQueryUSE = (cartodbId, useTable) => `SELECT ST_AsGeoJSON(st_makevali
         FROM ${useTable}
         WHERE cartodb_id = ${cartodbId}`;
 
-const createQueryWDPA = wdpaId => `SELECT ST_AsGeoJSON(st_makevalid(p.the_geom)) AS geojson, (ST_Area(geography(the_geom))/10000) as area_ha
+const createQueryWDPA = (wdpaId) => `SELECT ST_AsGeoJSON(st_makevalid(p.the_geom)) AS geojson, (ST_Area(geography(the_geom))/10000) as area_ha
         FROM (
           SELECT CASE
           WHEN marine::numeric = 2 THEN NULL
@@ -29,7 +29,7 @@ const createQueryWDPA = wdpaId => `SELECT ST_AsGeoJSON(st_makevalid(p.the_geom))
           WHERE wdpaid=${wdpaId}
         ) p`;
 
-const createQueryGeometry = data => `SELECT ST_AsGeoJson(ST_CollectionExtract(st_MakeValid(ST_GeomFromGeoJSON('${data}')),3)) as geojson`;
+const createQueryGeometry = (data) => `SELECT ST_AsGeoJson(ST_CollectionExtract(st_MakeValid(ST_GeomFromGeoJSON('${data}')),3)) as geojson`;
 
 module.exports = {
     createQueryID1,

--- a/app/test/e2e/utils/queries-v2.js
+++ b/app/test/e2e/utils/queries-v2.js
@@ -1,4 +1,4 @@
-const createQueryWDPA = wdpaId => `SELECT ST_AsGeoJSON(ST_MAKEVALID(p.the_geom)) AS geojson, (ST_Area(geography(the_geom))/10000) as area_ha
+const createQueryWDPA = (wdpaId) => `SELECT ST_AsGeoJSON(ST_MAKEVALID(p.the_geom)) AS geojson, (ST_Area(geography(the_geom))/10000) as area_ha
         FROM (
           SELECT CASE
           WHEN marine::numeric = 2 THEN NULL

--- a/app/test/e2e/v1/geostore-create.spec.js
+++ b/app/test/e2e/v1/geostore-create.spec.js
@@ -59,14 +59,14 @@ describe('Geostore v1 tests - Create geostores', () => {
             .send({
                 geojson: {
                     type: 'FeatureCollection',
-                    "properties": {
-                        "some": "property"
-                      },
+                    properties: {
+                        some: 'property'
+                    },
                     features: [{
                         type: 'Feature',
-                        "properties": {
-                        "some": "property"
-                      },
+                        properties: {
+                            some: 'property'
+                        },
                         geometry: {
                             type: 'MultiPoint',
                             coordinates: [

--- a/app/test/e2e/v1/geostore-create.spec.js
+++ b/app/test/e2e/v1/geostore-create.spec.js
@@ -2,6 +2,7 @@
 const nock = require('nock');
 const chai = require('chai');
 const config = require('config');
+const logger = require('logger');
 
 const { getTestServer } = require('../utils/test-server');
 
@@ -58,9 +59,14 @@ describe('Geostore v1 tests - Create geostores', () => {
             .send({
                 geojson: {
                     type: 'FeatureCollection',
+                    "properties": {
+                        "some": "property"
+                      },
                     features: [{
                         type: 'Feature',
-                        properties: {},
+                        "properties": {
+                        "some": "property"
+                      },
                         geometry: {
                             type: 'MultiPoint',
                             coordinates: [

--- a/app/test/e2e/v1/geostore-get-multiple.spec.js
+++ b/app/test/e2e/v1/geostore-get-multiple.spec.js
@@ -1,0 +1,121 @@
+/* eslint-disable no-unused-vars,no-undef */
+const nock = require('nock');
+const chai = require('chai');
+const config = require('config');
+const GeoStore = require('models/geoStore');
+const logger = require('logger');
+
+const { createGeostore, getUUID } = require('../utils/utils');
+const { getTestServer } = require('../utils/test-server');
+
+const should = chai.should();
+
+let requester;
+nock.disableNetConnect();
+nock.enableNetConnect(process.env.HOST_IP);
+
+describe('Geostore v1 tests - Get multiple geostorea', () => {
+
+    before(async () => {
+        if (process.env.NODE_ENV !== 'test') {
+            throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
+        }
+        if (config.get('cartoDB.user') === null) {
+            throw Error(`Carto user not set - please specify a CARTODB_USER env var with it.`);
+        }
+
+        requester = await getTestServer();
+
+        GeoStore.remove({}).exec();
+
+        nock.cleanAll();
+    });
+
+    it('Get geostores that have been saved to the local database should max of 2 geostores, return a 200', async () => {
+        const createdGeostore1 = await createGeostore({
+            areaHa: 205.64210228373287,
+            bbox: [],
+            info: {
+                iso: 'MCO', id1: null, id2: null, gadm: '2.8'
+            }
+        });
+        const createdGeostore2 = await createGeostore({
+            areaHa: 206.64210228373287,
+            bbox: [],
+            info: {
+                iso: 'BRA', id1: null, id2: null, gadm: '2.8'
+            }
+        });
+        const createdGeostore3 = await createGeostore({
+            areaHa: 207.64210228373287,
+            bbox: [],
+            info: {
+                iso: 'ESP', id1: null, id2: null, gadm: '2.8'
+            }
+        });
+
+        const response = await requester.post(`/api/v1/geostore/find-by-ids`)
+            .send({
+                geostores: [
+                    {
+                        geostore: createdGeostore1.hash
+                    }, {
+                        geostore: createdGeostore2.hash
+                    }, {
+                        geostore: createdGeostore3.hash
+                    }
+                ]
+            });
+
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array');
+        response.body.should.have.property('info').and.be.an('object');
+        response.body.info.should.have.property('found').and.equal(3);
+        response.body.info.should.have.property('returned').and.equal(2);
+        response.body.info.should.have.property('foundIds').and.be.an('array');
+
+    });
+
+    it('Get geostores some geostores that dont exist return a 200', async () => {
+        const createdGeostore1 = await createGeostore({
+            areaHa: 205.64210228373287,
+            bbox: [],
+            info: {
+                iso: 'MCO', id1: null, id2: null, gadm: '2.8'
+            }
+        });
+        const randomGeostoreID1 = getUUID();
+        const randomGeostoreID2 = getUUID();
+
+        const response = await requester.post(`/api/v1/geostore/find-by-ids`)
+            .send({
+                geostores: [
+                    {
+                        geostore: createdGeostore1.hash
+                    }, {
+                        geostore: randomGeostoreID1
+                    }, {
+                        geostore: randomGeostoreID2
+                    }
+                ]
+            });
+
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array');
+        response.body.should.have.property('info').and.be.an('object');
+        response.body.info.should.have.property('found').and.equal(1);
+        response.body.info.should.have.property('returned').and.equal(1);
+        response.body.info.should.have.property('foundIds').and.be.an('array');
+
+    });
+
+    afterEach(() => {
+        if (!nock.isDone()) {
+            throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
+        }
+    });
+
+    after(() => {
+        GeoStore.remove({}).exec();
+    });
+});

--- a/app/test/e2e/v1/geostore-get-national.spec.js
+++ b/app/test/e2e/v1/geostore-get-national.spec.js
@@ -4,6 +4,7 @@ const chai = require('chai');
 const config = require('config');
 const GeoStore = require('models/geoStore');
 
+const { createGeostore } = require('../utils/utils');
 const { getTestServer } = require('../utils/test-server');
 
 const should = chai.should();
@@ -84,7 +85,7 @@ describe('Geostore v1 tests - Get geostore - National level', () => {
             });
 
 
-        const response = await requester.get(`/api/v1/geostore/admin/MCO?simplify=0.005`).send();
+        const response = await requester.get(`/api/v1/geostore/admin/MCO`).send();
 
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('object');
@@ -104,7 +105,8 @@ describe('Geostore v1 tests - Get geostore - National level', () => {
     });
 
     it('Get country that has been saved to the local database should return a 200', async () => {
-        const response = await requester.get(`/api/v1/geostore/admin/MCO?simplify=0.005`).send();
+        const createdNational = await createGeostore({areaHa:205.64210228373287, bbox: [], info: { iso: 'MCO', id1: null, id2: null, gadm: '2.8'} });
+        const response = await requester.get(`/api/v1/geostore/admin/MCO`).send();
 
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('object');
@@ -120,7 +122,7 @@ describe('Geostore v1 tests - Get geostore - National level', () => {
 
         response.body.data.attributes.info.should.have.property('gadm').and.equal('2.8');
         response.body.data.attributes.info.should.have.property('iso').and.equal('MCO');
-        response.body.data.attributes.info.should.have.property('name');
+        
     });
 
     afterEach(() => {

--- a/app/test/e2e/v1/geostore-get-national.spec.js
+++ b/app/test/e2e/v1/geostore-get-national.spec.js
@@ -105,7 +105,13 @@ describe('Geostore v1 tests - Get geostore - National level', () => {
     });
 
     it('Get country that has been saved to the local database should return a 200', async () => {
-        const createdNational = await createGeostore({areaHa:205.64210228373287, bbox: [], info: { iso: 'MCO', id1: null, id2: null, gadm: '2.8'} });
+        const createdNational = await createGeostore({
+            areaHa: 205.64210228373287,
+            bbox: [],
+            info: {
+                iso: 'MCO', id1: null, id2: null, gadm: '2.8'
+            }
+        });
         const response = await requester.get(`/api/v1/geostore/admin/MCO`).send();
 
         response.status.should.equal(200);
@@ -122,7 +128,7 @@ describe('Geostore v1 tests - Get geostore - National level', () => {
 
         response.body.data.attributes.info.should.have.property('gadm').and.equal('2.8');
         response.body.data.attributes.info.should.have.property('iso').and.equal('MCO');
-        
+
     });
 
     afterEach(() => {

--- a/app/test/e2e/v1/geostore-get-regional.spec.js
+++ b/app/test/e2e/v1/geostore-get-regional.spec.js
@@ -57,7 +57,11 @@ describe('Geostore v1 tests - Get geostore sub sub national', () => {
         const testID = 123;
         const testID2 = 123;
         const testISO = 'TEST123';
-        const createdSubnational = await createGeostore({ info: { iso: testISO, id1: testID, id2: testID2, gadm: '2.8' } });
+        const createdSubnational = await createGeostore({
+            info: {
+                iso: testISO, id1: testID, id2: testID2, gadm: '2.8'
+            }
+        });
 
         const response = await subnational.get(`/${testISO}/${testID}/${testID2}`);
 

--- a/app/test/e2e/v1/geostore-get-regional.spec.js
+++ b/app/test/e2e/v1/geostore-get-regional.spec.js
@@ -57,7 +57,7 @@ describe('Geostore v1 tests - Get geostore sub sub national', () => {
         const testID = 123;
         const testID2 = 123;
         const testISO = 'TEST123';
-        const createdSubnational = await createGeostore({ info: { iso: testISO, id1: testID, id2: testID2 } });
+        const createdSubnational = await createGeostore({ info: { iso: testISO, id1: testID, id2: testID2, gadm: '2.8' } });
 
         const response = await subnational.get(`/${testISO}/${testID}/${testID2}`);
 

--- a/app/test/e2e/v1/geostore-get-subreional.spec.js
+++ b/app/test/e2e/v1/geostore-get-subreional.spec.js
@@ -54,7 +54,11 @@ describe('Geostore v1 tests - Get geostore subnational by id', () => {
     it('Getting subnational by id should return directly from db when it was created (happy case)', async () => {
         const testID = 123;
         const testISO = 'TEST123';
-        const createdSubnational = await createGeostore({ info: { iso: testISO, id1: testID , id2: null, gadm: '2.8'} });
+        const createdSubnational = await createGeostore({
+            info: {
+                iso: testISO, id1: testID, id2: null, gadm: '2.8'
+            }
+        });
 
         const response = await subnational.get(`/${testISO}/${testID}`);
 

--- a/app/test/e2e/v1/geostore-get-subreional.spec.js
+++ b/app/test/e2e/v1/geostore-get-subreional.spec.js
@@ -54,7 +54,7 @@ describe('Geostore v1 tests - Get geostore subnational by id', () => {
     it('Getting subnational by id should return directly from db when it was created (happy case)', async () => {
         const testID = 123;
         const testISO = 'TEST123';
-        const createdSubnational = await createGeostore({ info: { iso: testISO, id1: testID , id2: null} });
+        const createdSubnational = await createGeostore({ info: { iso: testISO, id1: testID , id2: null, gadm: '2.8'} });
 
         const response = await subnational.get(`/${testISO}/${testID}`);
 

--- a/app/test/e2e/v1/geostore-get-subreional.spec.js
+++ b/app/test/e2e/v1/geostore-get-subreional.spec.js
@@ -54,7 +54,7 @@ describe('Geostore v1 tests - Get geostore subnational by id', () => {
     it('Getting subnational by id should return directly from db when it was created (happy case)', async () => {
         const testID = 123;
         const testISO = 'TEST123';
-        const createdSubnational = await createGeostore({ info: { iso: testISO, id1: testID } });
+        const createdSubnational = await createGeostore({ info: { iso: testISO, id1: testID , id2: null} });
 
         const response = await subnational.get(`/${testISO}/${testID}`);
 

--- a/app/test/e2e/v2/geostore-create.spec.js
+++ b/app/test/e2e/v2/geostore-create.spec.js
@@ -3,6 +3,8 @@ const nock = require('nock');
 const chai = require('chai');
 const config = require('config');
 
+const logger = require('logger');
+
 const { getTestServer } = require('../utils/test-server');
 
 const should = chai.should();
@@ -62,7 +64,9 @@ describe('Geostore v2 tests - Create geostores', () => {
                     type: 'FeatureCollection',
                     features: [{
                         type: 'Feature',
-                        properties: {},
+                        "properties": {
+                        "some": "property"
+                      },
                         geometry: {
                             type: 'MultiPoint',
                             coordinates: [

--- a/app/test/e2e/v2/geostore-create.spec.js
+++ b/app/test/e2e/v2/geostore-create.spec.js
@@ -64,9 +64,9 @@ describe('Geostore v2 tests - Create geostores', () => {
                     type: 'FeatureCollection',
                     features: [{
                         type: 'Feature',
-                        "properties": {
-                        "some": "property"
-                      },
+                        properties: {
+                            some: 'property'
+                        },
                         geometry: {
                             type: 'MultiPoint',
                             coordinates: [

--- a/app/test/e2e/v2/geostore-get-multiple.spec.js
+++ b/app/test/e2e/v2/geostore-get-multiple.spec.js
@@ -14,7 +14,7 @@ let requester;
 nock.disableNetConnect();
 nock.enableNetConnect(process.env.HOST_IP);
 
-describe('Geostore v1 tests - Get multiple geostorea', () => {
+describe('Geostore v2 tests - Get multiple geostorea', () => {
 
     before(async () => {
         if (process.env.NODE_ENV !== 'test') {
@@ -36,25 +36,25 @@ describe('Geostore v1 tests - Get multiple geostorea', () => {
             areaHa: 205.64210228373287,
             bbox: [],
             info: {
-                iso: 'MCO', id1: null, id2: null, gadm: '2.8'
+                iso: 'MCO', id1: null, id2: null, gadm: '3.6'
             }
         });
         const createdGeostore2 = await createGeostore({
             areaHa: 206.64210228373287,
             bbox: [],
             info: {
-                iso: 'BRA', id1: null, id2: null, gadm: '2.8'
+                iso: 'BRA', id1: null, id2: null, gadm: '3.6'
             }
         });
         const createdGeostore3 = await createGeostore({
             areaHa: 207.64210228373287,
             bbox: [],
             info: {
-                iso: 'ESP', id1: null, id2: null, gadm: '2.8'
+                iso: 'ESP', id1: null, id2: null, gadm: '3.6'
             }
         });
 
-        const response = await requester.post(`/api/v1/geostore/find-by-ids`)
+        const response = await requester.post(`/api/v2/geostore/find-by-ids`)
             .send({
                 geostores: [createdGeostore1.hash, createdGeostore2.hash, createdGeostore3.hash]
             });
@@ -73,13 +73,13 @@ describe('Geostore v1 tests - Get multiple geostorea', () => {
             areaHa: 205.64210228373287,
             bbox: [],
             info: {
-                iso: 'MCO', id1: null, id2: null, gadm: '2.8'
+                iso: 'MCO', id1: null, id2: null, gadm: '3.6'
             }
         });
         const randomGeostoreID1 = getUUID();
         const randomGeostoreID2 = getUUID();
 
-        const response = await requester.post(`/api/v1/geostore/find-by-ids`)
+        const response = await requester.post(`/api/v2/geostore/find-by-ids`)
             .send({
                 geostores: [createdGeostore1.hash, randomGeostoreID1, randomGeostoreID2]
             });

--- a/app/test/unit/converters/geoJSONConverter.test.js
+++ b/app/test/unit/converters/geoJSONConverter.test.js
@@ -57,7 +57,7 @@ describe('Error serializer test', () => {
         feature.should.have.property('geometry');
         feature.geometry.should.be.an('object');
 
-        const geometry = feature.geometry;
+        const { geometry } = feature;
         geometry.should.have.property('type');
         geometry.type.should.be.equal(featureCollectionExample.features[0].geometry.type);
         geometry.should.have.a.property('coordinates');
@@ -79,7 +79,7 @@ describe('Error serializer test', () => {
         feature.should.have.property('geometry');
         feature.geometry.should.be.an('object');
 
-        const geometry = feature.geometry;
+        const { geometry } = feature;
         geometry.should.have.property('type');
         geometry.type.should.be.equal(featureCollectionExample.features[0].geometry.type);
         geometry.should.have.a.property('coordinates');
@@ -101,7 +101,7 @@ describe('Error serializer test', () => {
         feature.should.have.property('geometry');
         feature.geometry.should.be.an('object');
 
-        const geometry = feature.geometry;
+        const { geometry } = feature;
         geometry.should.have.property('type');
         geometry.type.should.be.equal(featureCollectionExample.features[0].geometry.type);
         geometry.should.have.a.property('coordinates');

--- a/app/test/unit/serializers/geoJSONSerializer.test.js
+++ b/app/test/unit/serializers/geoJSONSerializer.test.js
@@ -61,7 +61,7 @@ describe('GeoJSON serializer test', () => {
         const response = GeoJSONSerializer.serialize(single);
         response.should.not.be.an('array');
         response.should.have.property('data');
-        const data = response.data;
+        const { data } = response;
         data.should.have.property('type');
         data.should.have.property('attributes');
         data.should.have.property('id');
@@ -77,7 +77,7 @@ describe('GeoJSON serializer test', () => {
         feature.type.should.be.equal(single.geojson.features[0].type);
         feature.should.have.property('geometry');
         feature.geometry.should.be.an('object');
-        const geometry = feature.geometry;
+        const { geometry } = feature;
         geometry.should.have.property('type');
         geometry.type.should.be.equal(single.geojson.features[0].geometry.type);
         geometry.should.have.a.property('coordinates');
@@ -90,7 +90,7 @@ describe('GeoJSON serializer test', () => {
         const response = GeoJSONSerializer.serialize(severalFeatures);
         response.should.not.be.an('array');
         response.should.have.property('data');
-        const data = response.data;
+        const { data } = response;
         data.should.have.property('type');
         data.should.have.property('attributes');
         data.should.have.property('id');
@@ -106,7 +106,7 @@ describe('GeoJSON serializer test', () => {
         feature.type.should.be.equal(severalFeatures.geojson.features[0].type);
         feature.should.have.property('geometry');
         feature.geometry.should.be.an('object');
-        const geometry = feature.geometry;
+        const { geometry } = feature;
         geometry.should.have.property('type');
         geometry.type.should.be.equal(severalFeatures.geojson.features[0].geometry.type);
         geometry.should.have.a.property('coordinates');

--- a/config/default.json
+++ b/config/default.json
@@ -23,6 +23,6 @@
     "user": null
   },
   "constants": {
-    "maxGeostoresFoundById": 50
+    "maxGeostoresFoundById": 100
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -21,5 +21,8 @@
   },
   "cartoDB": {
     "user": null
+  },
+  "constants": {
+    "maxGeostoresFoundById": 50
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -9,5 +9,8 @@
     "database": "gfw_geostore_db_test",
     "host": "mymachine",
     "port": 27017
+  },
+  "constants": {
+    "maxGeostoresFoundById": 2
   }
 }


### PR DESCRIPTION
- Ups hard limit on number of geostores to request (50 --> 100)
- Changes expected POST payload to list of geostore strings (not object)
- Adds v2 endpoint (and test)