### PR TITLE
Remove duplicate geostores

### DIFF
--- a/app/src/routes/api/v1/geoStoreRouter.js
+++ b/app/src/routes/api/v1/geoStoreRouter.js
@@ -49,7 +49,7 @@ class GeoStoreRouter {
             this.throw(404, 'No GeoStores in payload');
             return;
         }
-        const ids = geostores.map(el => el.trim());
+        const ids = [...new Set(geostores.map(el => el.trim()))];
 
         logger.debug('Getting geostore by hash %s', ids);
 

--- a/app/src/routes/api/v2/geoStoreRouter.js
+++ b/app/src/routes/api/v2/geoStoreRouter.js
@@ -44,11 +44,12 @@ class GeoStoreRouterV2 {
     static async getMultipleGeoStores() {
         this.assert(this.request.body.geostores, 400, 'Geostores not found');
         const { geostores } = this.request.body;
+        // filter duplicates
         if (!geostores || geostores.length === 0) {
             this.throw(404, 'No GeoStores in payload');
             return;
         }
-        const ids = geostores.map(el => el.trim());
+        const ids = [...new Set(geostores.map(el => el.trim()))];
 
         logger.debug('Getting geostore by hash %s', ids);
 


### PR DESCRIPTION
Enhances the `/find-by-id` endpoint to remove duplicated geostore ids.