### PR TITLE
Attempting to fix random issues while creating geostores

### DIFF
--- a/app/src/routes/api/v1/geoStore.router.js
+++ b/app/src/routes/api/v1/geoStore.router.js
@@ -90,10 +90,6 @@ class GeoStoreRouter {
             }
 
             const geostore = await GeoStoreService.saveGeostore(ctx.request.body.geojson, data);
-            if (process.env.NODE_ENV !== 'test' || geostore.geojson.length < 2000) {
-                logger.debug(JSON.stringify(geostore.geojson));
-            }
-
             ctx.body = GeoJSONSerializer.serialize(geostore);
         } catch (err) {
             if (err instanceof ProviderNotFound || err instanceof GeoJSONNotFound) {

--- a/app/src/services/geoStoreService.js
+++ b/app/src/services/geoStoreService.js
@@ -218,17 +218,14 @@ class GeoStoreService {
             geoStore.bbox = turf.bbox(geoStore.geojson);
         }
 
-        await GeoStore.findOneAndUpdate({ hash: geoStore.hash }, geoStore, {
+        return GeoStore.findOneAndUpdate({ hash: geoStore.hash }, geoStore, {
             upsert: true,
             new: true,
-            runValidators: true
-        });
-
-        return GeoStore.findOne({
-            hash: geoStore.hash
-        }, {
-            'geojson._id': 0,
-            'geojson.features._id': 0
+            runValidators: true,
+            projection: {
+                'geojson._id': 0,
+                'geojson.features._id': 0
+            }
         });
     }
 


### PR DESCRIPTION
This PR addresses an issue reported by @edbrett via Slack, related to occasional 404 errors when POSTing to the /geostore endpoint with a valid data body. The returned message says "Cannot read property 'geojson' of null":

![Screenshot from 2020-09-01 16-37-40](https://user-images.githubusercontent.com/2981676/91873897-8086d100-ec71-11ea-8460-a84b331bb783.png)

These issues might be related to the replication we have in place for MongoDB, which sometimes (unpredictably) causes the geostore we created/updated to not be available right away (because the DB might still be propagating the changes to the replicas).

This PR is an attempt to fix these issues by removing the need for fetching the geostore immediately after creating/updating it - if the problem is related with MongoDB replication, this might fix it :crossed_fingers: